### PR TITLE
Child by field

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ assert root_node.end_point == (3, 13)
 
 function_node = root_node.children[0]
 assert root_node.type == 'function_definition'
+assert root_node.child_by_field_name('name').type == 'identifier'
 
 function_name_node = function_node.children[1]
 assert function_name_node.type == 'identifier'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -61,14 +61,25 @@ class TestTreeSitter(unittest.TestCase):
         root_node = tree.root_node
         fn_node = tree.root_node.children[0]
 
+        self.assertEqual(PYTHON.field_id_for_name('nameasdf'), None)
+        name_field = PYTHON.field_id_for_name('name')
+        alias_field = PYTHON.field_id_for_name('alias')
+        self.assertIsInstance(alias_field, int)
+        self.assertIsInstance(name_field, int)
         self.assertRaises(TypeError, root_node.child_by_field_id, '')
-        self.assertEqual(root_node.child_by_field_id(1), None)
-        self.assertEqual(root_node.child_by_field_id(16), None)
-        self.assertEqual(fn_node.child_by_field_id(1), None)
-        self.assertEqual(fn_node.child_by_field_id(16).type, 'identifier')
+        self.assertEqual(root_node.child_by_field_id(alias_field), None)
+        self.assertEqual(root_node.child_by_field_id(name_field), None)
+        self.assertEqual(fn_node.child_by_field_id(alias_field), None)
+        self.assertEqual(
+            fn_node.child_by_field_id(name_field).type,
+            'identifier'
+        )
         self.assertRaises(TypeError, root_node.child_by_field_name, True)
         self.assertRaises(TypeError, root_node.child_by_field_name, 1)
-        self.assertEqual(fn_node.child_by_field_name('name').type, 'identifier')
+        self.assertEqual(
+            fn_node.child_by_field_name('name').type,
+            'identifier'
+        )
         self.assertEqual(fn_node.child_by_field_name('asdfasdfname'), None)
 
     def test_node_children(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,6 +54,23 @@ class TestTreeSitter(unittest.TestCase):
             "'🐍'"
         )
 
+    def test_node_child_by_field_id(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        tree = parser.parse(b"def foo():\n  bar()")
+        root_node = tree.root_node
+        fn_node = tree.root_node.children[0]
+
+        try:
+            root_node.child_by_field_id('')
+            assert False
+        except TypeError:
+            pass
+        self.assertEqual(root_node.child_by_field_id(1), None)
+        self.assertEqual(root_node.child_by_field_id(16), None)
+        self.assertEqual(fn_node.child_by_field_id(1), None)
+        self.assertEqual(fn_node.child_by_field_id(16).type, 'identifier')
+
     def test_node_children(self):
         parser = Parser()
         parser.set_language(PYTHON)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -70,6 +70,8 @@ class TestTreeSitter(unittest.TestCase):
         self.assertEqual(root_node.child_by_field_id(16), None)
         self.assertEqual(fn_node.child_by_field_id(1), None)
         self.assertEqual(fn_node.child_by_field_id(16).type, 'identifier')
+        self.assertEqual(fn_node.child_by_field_name('name').type, 'identifier')
+        self.assertEqual(fn_node.child_by_field_name('asdfasdfname'), None)
 
     def test_node_children(self):
         parser = Parser()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -61,15 +61,13 @@ class TestTreeSitter(unittest.TestCase):
         root_node = tree.root_node
         fn_node = tree.root_node.children[0]
 
-        try:
-            root_node.child_by_field_id('')
-            assert False
-        except TypeError:
-            pass
+        self.assertRaises(TypeError, root_node.child_by_field_id, '')
         self.assertEqual(root_node.child_by_field_id(1), None)
         self.assertEqual(root_node.child_by_field_id(16), None)
         self.assertEqual(fn_node.child_by_field_id(1), None)
         self.assertEqual(fn_node.child_by_field_id(16).type, 'identifier')
+        self.assertRaises(TypeError, root_node.child_by_field_name, True)
+        self.assertRaises(TypeError, root_node.child_by_field_name, 1)
         self.assertEqual(fn_node.child_by_field_name('name').type, 'identifier')
         self.assertEqual(fn_node.child_by_field_name('asdfasdfname'), None)
 

--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -3,7 +3,7 @@ from ctypes import cdll, c_void_p
 from ctypes.util import find_library
 from distutils.ccompiler import new_compiler
 from tempfile import TemporaryDirectory
-from tree_sitter_binding import Parser, Tree
+from tree_sitter_binding import Parser, Tree, language_field_id_for_name
 import os.path as path
 import platform
 
@@ -78,3 +78,6 @@ class Language:
         language_function = getattr(self.lib, "tree_sitter_%s" % name)
         language_function.restype = c_void_p
         self.language_id = language_function()
+
+    def field_id_for_name(self, name):
+        return language_field_id_for_name(self.language_id, name)

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -504,7 +504,7 @@ static PyMethodDef parser_methods[] = {
     .ml_name = "set_language",
     .ml_meth = (PyCFunction)parser_set_language,
     .ml_flags = METH_O,
-    .ml_doc = "Parse source code, creating a syntax tree",
+    .ml_doc = "Set the parser language",
   },
   {NULL},
 };

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -90,6 +90,19 @@ static PyObject *node_chield_by_field_id(Node *self, PyObject *args) {
   return node_new_internal(child);
 }
 
+static PyObject *node_chield_by_field_name(Node *self, PyObject *args) {
+  char *name;
+  int length;
+  if (!PyArg_ParseTuple(args, "s#", &name, &length)) {
+    return NULL;
+  }
+  TSNode child = ts_node_child_by_field_name(self->node, name, length);
+  if (ts_node_is_null(child)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(child);
+}
+
 static PyObject *node_get_type(Node *self, void *payload) {
   return PyUnicode_FromString(ts_node_type(self->node));
 }
@@ -163,6 +176,12 @@ static PyMethodDef node_methods[] = {
     .ml_meth = (PyCFunction)node_chield_by_field_id,
     .ml_flags = METH_VARARGS,
     .ml_doc = "Get child for the given field id.",
+  },
+  {
+    .ml_name = "child_by_field_name",
+    .ml_meth = (PyCFunction)node_chield_by_field_name,
+    .ml_flags = METH_VARARGS,
+    .ml_doc = "Get child for the given field name.",
   },
   {NULL},
 };

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -278,7 +278,7 @@ static PyObject *tree_edit(Tree *self, PyObject *args, PyObject *kwargs) {
     };
     ts_tree_edit(self->tree, &edit);
   }
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef tree_methods[] = {
@@ -490,7 +490,7 @@ static PyObject *parser_set_language(Parser *self, PyObject *arg) {
   }
 
   ts_parser_set_language(self->parser, language);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef parser_methods[] = {

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -78,6 +78,18 @@ static PyObject *node_walk(Node *self, PyObject *args) {
   return tree_cursor_new_internal(self->node);
 }
 
+static PyObject *node_chield_by_field_id(Node *self, PyObject *args) {
+  TSFieldId field_id;
+  if (!PyArg_ParseTuple(args, "H", &field_id)) {
+    return NULL;
+  }
+  TSNode child = ts_node_child_by_field_id(self->node, field_id);
+  if (ts_node_is_null(child)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(child);
+}
+
 static PyObject *node_get_type(Node *self, void *payload) {
   return PyUnicode_FromString(ts_node_type(self->node));
 }
@@ -145,6 +157,12 @@ static PyMethodDef node_methods[] = {
     .ml_meth = (PyCFunction)node_sexp,
     .ml_flags = METH_NOARGS,
     .ml_doc = "Get an S-expression representing the name",
+  },
+  {
+    .ml_name = "child_by_field_id",
+    .ml_meth = (PyCFunction)node_chield_by_field_id,
+    .ml_flags = METH_VARARGS,
+    .ml_doc = "Get child for the given field id.",
   },
   {NULL},
 };

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -523,11 +523,39 @@ static PyTypeObject parser_type = {
 
 // Module
 
+
+static PyObject *language_field_id_for_name(Node *self, PyObject *args) {
+  TSLanguage *language;
+  char *field_name;
+  int length;
+  if (!PyArg_ParseTuple(args, "ls#", &language, &field_name, &length)) {
+    return NULL;
+  }
+
+  TSFieldId field_id = ts_language_field_id_for_name(language, field_name, length);
+  if (field_id == 0) {
+    Py_RETURN_NONE;
+  }
+
+  return PyLong_FromSize_t((size_t)field_id);
+}
+
+static PyMethodDef module_methods[] = {
+  {
+    .ml_name = "language_field_id_for_name",
+    .ml_meth = (PyCFunction)language_field_id_for_name,
+    .ml_flags = METH_VARARGS,
+    .ml_doc = "",
+  },
+  {NULL},
+};
+
 static struct PyModuleDef module_definition = {
   .m_base = PyModuleDef_HEAD_INIT,
   .m_name = "tree_sitter",
   .m_doc = NULL,
   .m_size = -1,
+  .m_methods = module_methods,
 };
 
 PyMODINIT_FUNC PyInit_tree_sitter_binding(void) {


### PR DESCRIPTION
Add methods `node.child_by_field_id` and `node.child_by_field_name`.

Also, fix a possible ref-counting bug by using the `Py_RETURN_NONE` macro.