### PR TITLE
Pythonic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tox
 build
 dist
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python: 3.6
+install: "pip install tox"
 
 script:
   - script/fetch-fixtures
-  - script/test
+  - tox
 
 branches:
   only:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.md
+include LICENSE
+prune tree_sitter/core
+graft tree_sitter/core/lib/src
+graft tree_sitter/core/lib/include/tree_sitter
+include tree_sitter/core/lib/utf8proc/*.c
+include tree_sitter/core/lib/utf8proc/*.h

--- a/Manifest.in
+++ b/Manifest.in
@@ -1,5 +1,0 @@
-include README.md
-include LICENSE
-include tree_sitter/core/lib/utf8proc/*
-include tree_sitter/core/lib/src/*
-include tree_sitter/core/lib/include/tree_sitter/*

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,48 @@
 """
 Py-Tree-sitter
 """
-
-import os
 import platform
-from setuptools import setup, Extension
+from os import path
 
-base_dir = os.path.dirname(__file__)
+from setuptools import Extension
+from setuptools import setup
 
-with open(os.path.join(base_dir, 'README.md')) as f:
-    long_description = f.read()
+
+with open(path.join(path.dirname(__file__), "README.md")) as f:
+    LONG_DESCRIPTION = f.read()
 
 setup(
-    name = "tree_sitter",
-    version = "0.0.8",
-    maintainer = "Max Brunsfeld",
-    maintainer_email = "maxbrunsfeld@gmail.com",
-    author = "Max Brunsfeld",
-    author_email = "maxbrunsfeld@gmail.com",
-    url = "https://github.com/tree-sitter/py-tree-sitter",
-    license = "MIT",
-    platforms = ["any"],
-    python_requires = ">=3.3",
-    description = "Python bindings to the Tree-sitter parsing library",
-    long_description = long_description,
-    long_description_content_type = "text/markdown",
-    classifiers = [
+    name="tree_sitter",
+    version="0.0.8",
+    maintainer="Max Brunsfeld",
+    maintainer_email="maxbrunsfeld@gmail.com",
+    author="Max Brunsfeld",
+    author_email="maxbrunsfeld@gmail.com",
+    url="https://github.com/tree-sitter/py-tree-sitter",
+    license="MIT",
+    platforms=["any"],
+    python_requires=">=3.3",
+    description="Python bindings to the Tree-sitter parsing library",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    classifiers=[
         "License :: OSI Approved :: MIT License",
         "Topic :: Software Development :: Compilers",
         "Topic :: Text Processing :: Linguistic",
     ],
-    packages = ['tree_sitter'],
-    ext_modules = [
+    packages=["tree_sitter"],
+    ext_modules=[
         Extension(
-            "tree_sitter_binding",
-            [
-                "tree_sitter/core/lib/src/lib.c",
-                "tree_sitter/binding.c",
-            ],
-            include_dirs = [
+            "tree_sitter.binding",
+            ["tree_sitter/core/lib/src/lib.c", "tree_sitter/binding.c"],
+            include_dirs=[
                 "tree_sitter/core/lib/include",
                 "tree_sitter/core/lib/utf8proc",
             ],
-            extra_compile_args = (
-                ['-std=c99'] if platform.system() != 'Windows' else None
-            )
+            extra_compile_args=(
+                ["-std=c99"] if platform.system() != "Windows" else None
+            ),
         )
     ],
-    project_urls = {
-        'Source': 'https://github.com/tree-sitter/py-tree-sitter',
-    }
+    project_urls={"Source": "https://github.com/tree-sitter/py-tree-sitter"},
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,10 +4,13 @@ from tree_sitter import Parser, Language
 
 
 LIB_PATH = path.join("build", "languages.so")
-Language.build_library(LIB_PATH, [
-    path.join("tests", "fixtures", "tree-sitter-python"),
-    path.join("tests", "fixtures", "tree-sitter-javascript"),
-])
+Language.build_library(
+    LIB_PATH,
+    [
+        path.join("tests", "fixtures", "tree-sitter-python"),
+        path.join("tests", "fixtures", "tree-sitter-javascript"),
+    ],
+)
 PYTHON = Language(LIB_PATH, "python")
 JAVASCRIPT = Language(LIB_PATH, "javascript")
 
@@ -17,6 +20,7 @@ class TestTreeSitter(unittest.TestCase):
         parser = Parser()
         parser.set_language(PYTHON)
         tree = parser.parse(b"def foo():\n  bar()")
+        # fmt: off
         self.assertEqual(
             tree.root_node.sexp(),
             "(module (function_definition "
@@ -36,6 +40,7 @@ class TestTreeSitter(unittest.TestCase):
                 "body: (statement_block "
                     "(expression_statement (call_expression function: (identifier) arguments: (arguments))))))"
         )
+        # fmt: on
 
     def test_multibyte_characters(self):
         parser = Parser()
@@ -50,8 +55,8 @@ class TestTreeSitter(unittest.TestCase):
         self.assertEqual(binary_node.type, "binary_expression")
         self.assertEqual(snake_node.type, "string")
         self.assertEqual(
-            source_code[snake_node.start_byte:snake_node.end_byte].decode('utf8'),
-            "'🐍'"
+            source_code[snake_node.start_byte : snake_node.end_byte].decode("utf8"),
+            "'🐍'",
         )
 
     def test_node_child_by_field_id(self):
@@ -61,26 +66,20 @@ class TestTreeSitter(unittest.TestCase):
         root_node = tree.root_node
         fn_node = tree.root_node.children[0]
 
-        self.assertEqual(PYTHON.field_id_for_name('nameasdf'), None)
-        name_field = PYTHON.field_id_for_name('name')
-        alias_field = PYTHON.field_id_for_name('alias')
+        self.assertEqual(PYTHON.field_id_for_name("nameasdf"), None)
+        name_field = PYTHON.field_id_for_name("name")
+        alias_field = PYTHON.field_id_for_name("alias")
         self.assertIsInstance(alias_field, int)
         self.assertIsInstance(name_field, int)
-        self.assertRaises(TypeError, root_node.child_by_field_id, '')
+        self.assertRaises(TypeError, root_node.child_by_field_id, "")
         self.assertEqual(root_node.child_by_field_id(alias_field), None)
         self.assertEqual(root_node.child_by_field_id(name_field), None)
         self.assertEqual(fn_node.child_by_field_id(alias_field), None)
-        self.assertEqual(
-            fn_node.child_by_field_id(name_field).type,
-            'identifier'
-        )
+        self.assertEqual(fn_node.child_by_field_id(name_field).type, "identifier")
         self.assertRaises(TypeError, root_node.child_by_field_name, True)
         self.assertRaises(TypeError, root_node.child_by_field_name, 1)
-        self.assertEqual(
-            fn_node.child_by_field_name('name').type,
-            'identifier'
-        )
-        self.assertEqual(fn_node.child_by_field_name('asdfasdfname'), None)
+        self.assertEqual(fn_node.child_by_field_name("name").type, "identifier")
+        self.assertEqual(fn_node.child_by_field_name("asdfasdfname"), None)
 
     def test_node_children(self):
         parser = Parser()
@@ -173,28 +172,29 @@ class TestTreeSitter(unittest.TestCase):
 
         edit_offset = len(b"def foo(")
         tree.edit(
-            start_byte = edit_offset,
-            old_end_byte = edit_offset,
-            new_end_byte = edit_offset + 2,
-            start_point = (0, edit_offset),
-            old_end_point = (0, edit_offset),
-            new_end_point = (0, edit_offset + 2),
+            start_byte=edit_offset,
+            old_end_byte=edit_offset,
+            new_end_byte=edit_offset + 2,
+            start_point=(0, edit_offset),
+            old_end_point=(0, edit_offset),
+            new_end_point=(0, edit_offset + 2),
         )
 
         fn_node = tree.root_node.children[0]
-        self.assertEqual(fn_node.type, 'function_definition')
+        self.assertEqual(fn_node.type, "function_definition")
         self.assertTrue(fn_node.has_changes)
         self.assertFalse(fn_node.children[0].has_changes)
         self.assertFalse(fn_node.children[1].has_changes)
         self.assertFalse(fn_node.children[3].has_changes)
 
         params_node = fn_node.children[2]
-        self.assertEqual(params_node.type, 'parameters')
+        self.assertEqual(params_node.type, "parameters")
         self.assertTrue(params_node.has_changes)
         self.assertEqual(params_node.start_point, (0, edit_offset - 1))
         self.assertEqual(params_node.end_point, (0, edit_offset + 3))
 
         new_tree = parser.parse(b"def foo(ab):\n  bar()", tree)
+        # fmt: off
         self.assertEqual(
             new_tree.root_node.sexp(),
             "(module (function_definition "
@@ -205,3 +205,4 @@ class TestTreeSitter(unittest.TestCase):
                         "function: (identifier) "
                         "arguments: (argument_list))))))"
         )
+        # fmt: on

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -1,6 +1,8 @@
 import unittest
-import os.path as path
-from tree_sitter import Parser, Language
+from os import path
+
+from tree_sitter import Language
+from tree_sitter import Parser
 
 
 LIB_PATH = path.join("build", "languages.so")

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,10 @@ deps =
     flake8
     pylint
 commands =
-    black tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
-    -flake8 tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
-    -pylint tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
+    black -l 79 tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
+    flake8 tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
+    pylint tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
 
 [flake8]
 exclude = node_modules
-ignore = E203,W503
+ignore = E203,W503,F401

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = lint, py
+
+[testenv:py]
+deps = pytest
+commands = pytest {posargs:tests}
+
+[testenv:lint]
+deps =
+    black
+    flake8
+    pylint
+commands =
+    black tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
+    -flake8 tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
+    -pylint tree_sitter/__init__.py setup.py tests/test_tree_sitter.py
+
+[flake8]
+exclude = node_modules
+ignore = E203,W503

--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -1,3 +1,5 @@
+"""Python bindings for tree-sitter."""
+
 import platform
 from ctypes import c_void_p
 from ctypes import cdll
@@ -6,6 +8,7 @@ from distutils.ccompiler import new_compiler
 from os import path
 from tempfile import TemporaryDirectory
 
+# pylint: disable=no-name-in-module
 from tree_sitter.binding import _language_field_id_for_name
 from tree_sitter.binding import Node
 from tree_sitter.binding import Parser
@@ -26,27 +29,26 @@ class Language:
         the library already existed and was modified more recently than
         any of the source files.
         """
-        output_mtime = 0
-        if path.exists(output_path):
-            output_mtime = path.getmtime(output_path)
+        output_mtime = (
+            path.getmtime(output_path) if path.exists(output_path) else 0
+        )
 
         if not repo_paths:
             raise ValueError("Must provide at least one language folder")
 
         cpp = False
         source_paths = []
-        source_mtimes = [path.getmtime(__file__)]
         for repo_path in repo_paths:
             src_path = path.join(repo_path, "src")
             source_paths.append(path.join(src_path, "parser.c"))
-            source_mtimes.append(path.getmtime(source_paths[-1]))
             if path.exists(path.join(src_path, "scanner.cc")):
                 cpp = True
                 source_paths.append(path.join(src_path, "scanner.cc"))
-                source_mtimes.append(path.getmtime(source_paths[-1]))
             elif path.exists(path.join(src_path, "scanner.c")):
                 source_paths.append(path.join(src_path, "scanner.c"))
-                source_mtimes.append(path.getmtime(source_paths[-1]))
+        source_mtimes = [path.getmtime(__file__)] + [
+            path.getmtime(path_) for path_ in source_paths
+        ]
 
         compiler = new_compiler()
         if cpp:

--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -8,7 +8,7 @@ from distutils.ccompiler import new_compiler
 from os import path
 from tempfile import TemporaryDirectory
 
-# pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module,import-error
 from tree_sitter.binding import _language_field_id_for_name
 from tree_sitter.binding import Node
 from tree_sitter.binding import Parser

--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -1,14 +1,22 @@
-from types import MethodType
-from ctypes import cdll, c_void_p
+import platform
+from ctypes import c_void_p
+from ctypes import cdll
 from ctypes.util import find_library
 from distutils.ccompiler import new_compiler
+from os import path
 from tempfile import TemporaryDirectory
-from tree_sitter_binding import Parser, Tree, language_field_id_for_name
-import os.path as path
-import platform
+
+from tree_sitter.binding import _language_field_id_for_name
+from tree_sitter.binding import Node
+from tree_sitter.binding import Parser
+from tree_sitter.binding import Tree
+from tree_sitter.binding import TreeCursor
 
 
 class Language:
+    """A tree-sitter language"""
+
+    @staticmethod
     def build_library(output_path, repo_paths):
         """
         Build a dynamic library at the given path, based on the parser
@@ -22,14 +30,14 @@ class Language:
         if path.exists(output_path):
             output_mtime = path.getmtime(output_path)
 
-        if len(repo_paths) == 0:
-            raise ValueError('Must provide at least one language folder')
+        if not repo_paths:
+            raise ValueError("Must provide at least one language folder")
 
         cpp = False
         source_paths = []
         source_mtimes = [path.getmtime(__file__)]
         for repo_path in repo_paths:
-            src_path = path.join(repo_path, 'src')
+            src_path = path.join(repo_path, "src")
             source_paths.append(path.join(src_path, "parser.c"))
             source_mtimes.append(path.getmtime(source_paths[-1]))
             if path.exists(path.join(src_path, "scanner.cc")):
@@ -42,31 +50,33 @@ class Language:
 
         compiler = new_compiler()
         if cpp:
-            if find_library('c++'):
-                compiler.add_library('c++')
-            elif find_library('stdc++'):
-                compiler.add_library('stdc++')
+            if find_library("c++"):
+                compiler.add_library("c++")
+            elif find_library("stdc++"):
+                compiler.add_library("stdc++")
 
-        if max(source_mtimes) > output_mtime:
-            with TemporaryDirectory(suffix = 'tree_sitter_language') as dir:
-                object_paths = []
-                for source_path in source_paths:
-                    if platform.system() == 'Windows':
-                        flags = None
-                    else:
-                        flags = ['-fPIC']
-                        if source_path.endswith('.c'):
-                            flags.append('-std=c99')
-                    object_paths.append(compiler.compile(
-                        [source_path],
-                        output_dir = dir,
-                        include_dirs = [path.dirname(source_path)],
-                        extra_preargs = flags
-                    )[0])
-                compiler.link_shared_object(object_paths, output_path)
-            return True
-        else:
+        if max(source_mtimes) <= output_mtime:
             return False
+
+        with TemporaryDirectory(suffix="tree_sitter_language") as out_dir:
+            object_paths = []
+            for source_path in source_paths:
+                if platform.system() == "Windows":
+                    flags = None
+                else:
+                    flags = ["-fPIC"]
+                    if source_path.endswith(".c"):
+                        flags.append("-std=c99")
+                object_paths.append(
+                    compiler.compile(
+                        [source_path],
+                        output_dir=out_dir,
+                        include_dirs=[path.dirname(source_path)],
+                        extra_preargs=flags,
+                    )[0]
+                )
+            compiler.link_shared_object(object_paths, output_path)
+        return True
 
     def __init__(self, library_path, name):
         """
@@ -80,4 +90,5 @@ class Language:
         self.language_id = language_function()
 
     def field_id_for_name(self, name):
-        return language_field_id_for_name(self.language_id, name)
+        """Return the field id for a field name."""
+        return _language_field_id_for_name(self.language_id, name)

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -163,25 +163,29 @@ static PyMethodDef node_methods[] = {
     .ml_name = "walk",
     .ml_meth = (PyCFunction)node_walk,
     .ml_flags = METH_NOARGS,
-    .ml_doc = "Get a tree cursor for walking the tree starting at this node",
+    .ml_doc = "walk()\n--\n\n\
+               Get a tree cursor for walking the tree starting at this node.",
   },
   {
     .ml_name = "sexp",
     .ml_meth = (PyCFunction)node_sexp,
     .ml_flags = METH_NOARGS,
-    .ml_doc = "Get an S-expression representing the name",
+    .ml_doc = "sexp()\n--\n\n\
+               Get an S-expression representing the node.",
   },
   {
     .ml_name = "child_by_field_id",
     .ml_meth = (PyCFunction)node_chield_by_field_id,
     .ml_flags = METH_VARARGS,
-    .ml_doc = "Get child for the given field id.",
+    .ml_doc = "child_by_field_id(id)\n--\n\n\
+               Get child for the given field id.",
   },
   {
     .ml_name = "child_by_field_name",
     .ml_meth = (PyCFunction)node_chield_by_field_name,
     .ml_flags = METH_VARARGS,
-    .ml_doc = "Get child for the given field name.",
+    .ml_doc = "child_by_field_name(name)\n--\n\n\
+               Get child for the given field name.",
   },
   {NULL},
 };
@@ -286,19 +290,22 @@ static PyMethodDef tree_methods[] = {
     .ml_name = "walk",
     .ml_meth = (PyCFunction)tree_walk,
     .ml_flags = METH_NOARGS,
-    .ml_doc = "Get a tree cursor for walking this tree",
+    .ml_doc = "walk()\n--\n\n\
+               Get a tree cursor for walking this tree.",
   },
   {
     .ml_name = "edit",
     .ml_meth = (PyCFunction)tree_edit,
     .ml_flags = METH_KEYWORDS|METH_VARARGS,
-    .ml_doc = "Edit a syntax tree",
+    .ml_doc = "edit(start_byte, old_end_byte, new_end_byte,\
+               start_point, old_end_point, new_end_point)\n--\n\n\
+               Edit the syntax tree.",
   },
   {NULL},
 };
 
 static PyGetSetDef tree_accessors[] = {
-  {"root_node", (getter)tree_get_root_node, NULL, "root node", NULL},
+  {"root_node", (getter)tree_get_root_node, NULL, "The root node of this tree.", NULL},
   {NULL}
 };
 
@@ -369,32 +376,41 @@ static PyMethodDef tree_cursor_methods[] = {
     .ml_name = "goto_parent",
     .ml_meth = (PyCFunction)tree_cursor_goto_parent,
     .ml_flags = METH_NOARGS,
-    .ml_doc = "If the current node is not the root, move to its parent and return True. Otherwise, return false.",
+    .ml_doc = "goto_parent()\n--\n\n\
+               Go to parent.\n\n\
+               If the current node is not the root, move to its parent and\n\
+               return True. Otherwise, return False.",
   },
   {
     .ml_name = "goto_first_child",
     .ml_meth = (PyCFunction)tree_cursor_goto_first_child,
     .ml_flags = METH_NOARGS,
-    .ml_doc = "If the current node has children, move to the first child and return True. Otherwise, return false.",
+    .ml_doc = "goto_first_child()\n--\n\n\
+               Go to first child.\n\n\
+               If the current node has children, move to the first child and\n\
+               return True. Otherwise, return False.",
   },
   {
     .ml_name = "goto_next_sibling",
     .ml_meth = (PyCFunction)tree_cursor_goto_next_sibling,
     .ml_flags = METH_NOARGS,
-    .ml_doc = "If the current node has a next sibling, move to the next sibling and return True. Otherwise, return false.",
+    .ml_doc = "goto_next_sibling()\n--\n\n\
+               Go to next sibling.\n\n\
+               If the current node has a next sibling, move to the next sibling\n\
+               and return True. Otherwise, return False.",
   },
   {NULL},
 };
 
 static PyGetSetDef tree_cursor_accessors[] = {
-  {"node", (getter)tree_cursor_get_node, NULL, "node", NULL},
+  {"node", (getter)tree_cursor_get_node, NULL, "The current node.", NULL},
   {NULL},
 };
 
 static PyTypeObject tree_cursor_type = {
   PyVarObject_HEAD_INIT(NULL, 0)
   .tp_name = "tree_sitter.TreeCursor",
-  .tp_doc = "A syntax tree cursor",
+  .tp_doc = "A syntax tree cursor.",
   .tp_basicsize = sizeof(TreeCursor),
   .tp_itemsize = 0,
   .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -498,13 +514,15 @@ static PyMethodDef parser_methods[] = {
     .ml_name = "parse",
     .ml_meth = (PyCFunction)parser_parse,
     .ml_flags = METH_VARARGS,
-    .ml_doc = "Parse source code, creating a syntax tree",
+    .ml_doc = "parse(bytes, old_tree=None)\n--\n\n\
+               Parse source code, creating a syntax tree.",
   },
   {
     .ml_name = "set_language",
     .ml_meth = (PyCFunction)parser_set_language,
     .ml_flags = METH_O,
-    .ml_doc = "Set the parser language",
+    .ml_doc = "set_language(language)\n--\n\n\
+               Set the parser language.",
   },
   {NULL},
 };
@@ -542,23 +560,23 @@ static PyObject *language_field_id_for_name(Node *self, PyObject *args) {
 
 static PyMethodDef module_methods[] = {
   {
-    .ml_name = "language_field_id_for_name",
+    .ml_name = "_language_field_id_for_name",
     .ml_meth = (PyCFunction)language_field_id_for_name,
     .ml_flags = METH_VARARGS,
-    .ml_doc = "",
+    .ml_doc = "(internal)",
   },
   {NULL},
 };
 
 static struct PyModuleDef module_definition = {
   .m_base = PyModuleDef_HEAD_INIT,
-  .m_name = "tree_sitter",
+  .m_name = "binding",
   .m_doc = NULL,
   .m_size = -1,
   .m_methods = module_methods,
 };
 
-PyMODINIT_FUNC PyInit_tree_sitter_binding(void) {
+PyMODINIT_FUNC PyInit_binding(void) {
   PyObject *module = PyModule_Create(&module_definition);
   if (module == NULL) return NULL;
 


### PR DESCRIPTION
Add function signatures to documentation, also re-export Node and
TreeCursor so that the documentation can be obtained.

Also, move the compiled bindings to tree_sitter.binding, otherwise a
second global Python module is created.

Also, run black on the Python sources, ensuring PEP 8 compliance.