### PR TITLE
More bindings

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -235,7 +235,6 @@ class TestNode(TestCase):
         self.assertEqual(close_delim_node.parent,
                          list_node)
 
-
         self.assertEqual(list_node.child_count, 7)
         self.assertEqual(list_node.named_child_count, 3)
 

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -139,6 +139,106 @@ class TestNode(TestCase):
         self.assertEqual(statement_node.type, "block")
         self.assertEqual(statement_node.is_named, True)
 
+    def test_named_and_sibling_and_count_and_parent(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        tree = parser.parse(b"[1, 2, 3]")
+
+        root_node = tree.root_node
+        self.assertEqual(root_node.type, "module")
+        self.assertEqual(root_node.start_byte, 0)
+        self.assertEqual(root_node.end_byte, 9)
+        self.assertEqual(root_node.start_point, (0, 0))
+        self.assertEqual(root_node.end_point, (0, 9))
+
+        exp_stmt_node = root_node.children[0]
+        self.assertEqual(exp_stmt_node.type, "expression_statement")
+        self.assertEqual(exp_stmt_node.start_byte, 0)
+        self.assertEqual(exp_stmt_node.end_byte, 9)
+        self.assertEqual(exp_stmt_node.start_point, (0, 0))
+        self.assertEqual(exp_stmt_node.end_point, (0, 9))
+        self.assertEqual(exp_stmt_node.parent,
+                         root_node)
+
+        list_node = exp_stmt_node.children[0]
+        self.assertEqual(list_node.type, "list")
+        self.assertEqual(list_node.start_byte, 0)
+        self.assertEqual(list_node.end_byte, 9)
+        self.assertEqual(list_node.start_point, (0, 0))
+        self.assertEqual(list_node.end_point, (0, 9))
+        self.assertEqual(list_node.parent,
+                         exp_stmt_node)
+
+        open_delim_node = list_node.children[0]
+        self.assertEqual(open_delim_node.type, "[")
+        self.assertEqual(open_delim_node.start_byte, 0)
+        self.assertEqual(open_delim_node.end_byte, 1)
+        self.assertEqual(open_delim_node.start_point, (0, 0))
+        self.assertEqual(open_delim_node.end_point, (0, 1))
+        self.assertEqual(open_delim_node.parent,
+                         list_node)
+
+        first_num_node = list_node.children[1]
+        self.assertEqual(first_num_node,
+                         open_delim_node.next_named_sibling)
+        self.assertEqual(first_num_node.parent,
+                         list_node)
+
+        first_comma_node = list_node.children[2]
+        self.assertEqual(first_comma_node,
+                         first_num_node.next_sibling)
+        self.assertEqual(first_num_node,
+                         first_comma_node.prev_sibling)
+        self.assertEqual(first_comma_node.parent,
+                         list_node)
+
+        second_num_node = list_node.children[3]
+        self.assertEqual(second_num_node,
+                         first_comma_node.next_sibling)
+        self.assertEqual(second_num_node,
+                         first_num_node.next_named_sibling)
+        self.assertEqual(first_num_node,
+                         second_num_node.prev_named_sibling)
+        self.assertEqual(second_num_node.parent,
+                         list_node)
+
+        second_comma_node = list_node.children[4]
+        self.assertEqual(second_comma_node,
+                         second_num_node.next_sibling)
+        self.assertEqual(second_num_node,
+                         second_comma_node.prev_sibling)
+        self.assertEqual(second_comma_node.parent,
+                         list_node)
+
+        third_num_node = list_node.children[5]
+        self.assertEqual(third_num_node,
+                         second_comma_node.next_sibling)
+        self.assertEqual(third_num_node,
+                         second_num_node.next_named_sibling)
+        self.assertEqual(second_num_node,
+                         third_num_node.prev_named_sibling)
+        self.assertEqual(third_num_node.parent,
+                         list_node)
+
+        close_delim_node = list_node.children[6]
+        self.assertEqual(close_delim_node.type, "]")
+        self.assertEqual(close_delim_node.start_byte, 8)
+        self.assertEqual(close_delim_node.end_byte, 9)
+        self.assertEqual(close_delim_node.start_point, (0, 8))
+        self.assertEqual(close_delim_node.end_point, (0, 9))
+        self.assertEqual(close_delim_node,
+                         third_num_node.next_sibling)
+        self.assertEqual(third_num_node,
+                         close_delim_node.prev_sibling)
+        self.assertEqual(third_num_node,
+                         close_delim_node.prev_named_sibling)
+        self.assertEqual(close_delim_node.parent,
+                         list_node)
+
+
+        self.assertEqual(list_node.child_count, 7)
+        self.assertEqual(list_node.named_child_count, 3)
+
     def test_tree(self):
         code = b"def foo():\n  bar()\n\ndef foo():\n  bar()"
         parser = Parser()

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -138,6 +138,10 @@ static PyObject *node_get_is_named(Node *self, void *payload) {
   return PyBool_FromLong(ts_node_is_named(self->node));
 }
 
+static PyObject *node_get_is_missing(Node *self, void *payload) {
+  return PyBool_FromLong(ts_node_is_missing(self->node));
+}
+
 static PyObject *node_get_has_changes(Node *self, void *payload) {
   return PyBool_FromLong(ts_node_has_changes(self->node));
 }
@@ -185,6 +189,60 @@ static PyObject *node_get_children(Node *self, void *payload) {
   return result;
 }
 
+static PyObject *node_get_child_count(Node *self, void *payload) {
+  long length = (long)ts_node_child_count(self->node);
+  PyObject *result = PyLong_FromLong(length);
+  Py_INCREF(result);
+  return result;
+}
+
+static PyObject *node_get_named_child_count(Node *self, void *payload) {
+  long length = (long)ts_node_named_child_count(self->node);
+  PyObject *result = PyLong_FromLong(length);
+  Py_INCREF(result);
+  return result;
+}
+
+static PyObject *node_get_next_sibling(Node *self, void *payload) {
+  TSNode next_sibling = ts_node_next_sibling(self->node);
+  if (ts_node_is_null(next_sibling)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(next_sibling, self->tree);
+}
+
+static PyObject *node_get_prev_sibling(Node *self, void *payload) {
+  TSNode prev_sibling = ts_node_prev_sibling(self->node);
+  if (ts_node_is_null(prev_sibling)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(prev_sibling, self->tree);
+}
+
+static PyObject *node_get_next_named_sibling(Node *self, void *payload) {
+  TSNode next_named_sibling = ts_node_next_named_sibling(self->node);
+  if (ts_node_is_null(next_named_sibling)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(next_named_sibling, self->tree);
+}
+
+static PyObject *node_get_prev_named_sibling(Node *self, void *payload) {
+  TSNode prev_named_sibling = ts_node_prev_named_sibling(self->node);
+  if (ts_node_is_null(prev_named_sibling)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(prev_named_sibling, self->tree);
+}
+
+static PyObject *node_get_parent(Node *self, void *payload) {
+  TSNode parent = ts_node_parent(self->node);
+  if (ts_node_is_null(parent)) {
+    Py_RETURN_NONE;
+  }
+  return node_new_internal(parent, self->tree);
+}
+
 static PyMethodDef node_methods[] = {
   {
     .ml_name = "walk",
@@ -220,6 +278,7 @@ static PyMethodDef node_methods[] = {
 static PyGetSetDef node_accessors[] = {
   {"type", (getter)node_get_type, NULL, "The node's type", NULL},
   {"is_named", (getter)node_get_is_named, NULL, "Is this a named node", NULL},
+  {"is_missing", (getter)node_get_is_missing, NULL, "Is this a node inserted by the parser", NULL},
   {"has_changes", (getter)node_get_has_changes, NULL, "Does this node have text changes since it was parsed", NULL},
   {"has_error", (getter)node_get_has_error, NULL, "Does this node contain any errors", NULL},
   {"start_byte", (getter)node_get_start_byte, NULL, "The node's start byte", NULL},
@@ -227,6 +286,13 @@ static PyGetSetDef node_accessors[] = {
   {"start_point", (getter)node_get_start_point, NULL, "The node's start point", NULL},
   {"end_point", (getter)node_get_end_point, NULL, "The node's end point", NULL},
   {"children", (getter)node_get_children, NULL, "The node's children", NULL},
+  {"child_count", (getter)node_get_child_count, NULL, "The number of children for a node", NULL},
+  {"named_child_count", (getter)node_get_named_child_count, NULL, "The number of named children for a node", NULL},
+  {"next_sibling", (getter)node_get_next_sibling, NULL, "The node's next sibling", NULL},
+  {"prev_sibling", (getter)node_get_prev_sibling, NULL, "The node's previous sibling", NULL},
+  {"next_named_sibling", (getter)node_get_next_named_sibling, NULL, "The node's next named sibling", NULL},
+  {"prev_named_sibling", (getter)node_get_prev_named_sibling, NULL, "The node's previous named sibling", NULL},
+  {"parent", (getter)node_get_parent, NULL, "The node's parent", NULL},
   {NULL}
 };
 


### PR DESCRIPTION
This PR attempts to add a few more bindings (with tests) for:

* `child_count`
* `named_child_count`
* `next_sibling`
* `prev_sibling`
* `next_named_sibling`
* `prev_named_sibling`
* `parent`

There is also a binding for `is_missing` but it lacks a test as I don't have sample source for JavaScript or Python that produces that condition.

If someone has an example of that I might be able to add a test for it.

<s>BTW, I ran the tests successfully with tree-sitter-python's `tree-sitter-cli` dev dependency in `package.json` set to something in the 0.16.x series as I failed to have the 0.17.x series (i.e. master branch) work with the tests.</s>

See below for update.