### PR TITLE
Node text

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -238,6 +238,70 @@ class TestNode(TestCase):
         self.assertEqual(list_node.child_count, 7)
         self.assertEqual(list_node.named_child_count, 3)
 
+    def test_node_text(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        tree = parser.parse(b"[1, 2, 3]")
+
+        root_node = tree.root_node
+        print(root_node.text)
+
+        exp_stmt_node = root_node.children[0]
+        print(exp_stmt_node.text)
+
+        list_node = exp_stmt_node.children[0]
+        print(list_node.text)
+
+        open_delim_node = list_node.children[0]
+        print(open_delim_node.text)
+
+        first_num_node = list_node.children[1]
+        print(first_num_node.text)
+
+        first_comma_node = list_node.children[2]
+        print(first_comma_node.text)
+
+        second_num_node = list_node.children[3]
+        print(second_num_node.text)
+
+        second_comma_node = list_node.children[4]
+        print(second_comma_node.text)
+
+        third_num_node = list_node.children[5]
+        print(third_num_node.text)
+
+        close_delim_node = list_node.children[6]
+        print(close_delim_node.text)
+
+    def test_node_text_2(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        tree = parser.parse(b"[0, [1, 2, 3]]")
+
+        root_node = tree.root_node
+        print(root_node.text)
+
+        exp_stmt_node = root_node.children[0]
+        print(exp_stmt_node.text)
+
+        list_node = exp_stmt_node.children[0]
+        print(list_node.text)
+
+        open_delim_node = list_node.children[0]
+        print(open_delim_node.text)
+
+        first_num_node = list_node.children[1]
+        print(first_num_node.text)
+
+        first_comma_node = list_node.children[2]
+        print(first_comma_node.text)
+
+        child_list_node = list_node.children[3]
+        print(child_list_node.text)
+
+        close_delim_node = list_node.children[4]
+        print(close_delim_node.text)
+
     def test_tree(self):
         code = b"def foo():\n  bar()\n\ndef foo():\n  bar()"
         parser = Parser()

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -241,66 +241,47 @@ class TestNode(TestCase):
     def test_node_text(self):
         parser = Parser()
         parser.set_language(PYTHON)
-        tree = parser.parse(b"[1, 2, 3]")
-
-        root_node = tree.root_node
-        print(root_node.text)
-
-        exp_stmt_node = root_node.children[0]
-        print(exp_stmt_node.text)
-
-        list_node = exp_stmt_node.children[0]
-        print(list_node.text)
-
-        open_delim_node = list_node.children[0]
-        print(open_delim_node.text)
-
-        first_num_node = list_node.children[1]
-        print(first_num_node.text)
-
-        first_comma_node = list_node.children[2]
-        print(first_comma_node.text)
-
-        second_num_node = list_node.children[3]
-        print(second_num_node.text)
-
-        second_comma_node = list_node.children[4]
-        print(second_comma_node.text)
-
-        third_num_node = list_node.children[5]
-        print(third_num_node.text)
-
-        close_delim_node = list_node.children[6]
-        print(close_delim_node.text)
-
-    def test_node_text_2(self):
-        parser = Parser()
-        parser.set_language(PYTHON)
         tree = parser.parse(b"[0, [1, 2, 3]]")
 
+        self.assertEqual(tree.text, b"[0, [1, 2, 3]]")
+
         root_node = tree.root_node
-        print(root_node.text)
+        self.assertEqual(root_node.text, b'[0, [1, 2, 3]]')
 
         exp_stmt_node = root_node.children[0]
-        print(exp_stmt_node.text)
+        self.assertEqual(exp_stmt_node.text, b'[0, [1, 2, 3]]')
 
         list_node = exp_stmt_node.children[0]
-        print(list_node.text)
+        self.assertEqual(list_node.text, b'[0, [1, 2, 3]]')
 
         open_delim_node = list_node.children[0]
-        print(open_delim_node.text)
+        self.assertEqual(open_delim_node.text, b'[')
 
         first_num_node = list_node.children[1]
-        print(first_num_node.text)
+        self.assertEqual(first_num_node.text, b'0')
 
         first_comma_node = list_node.children[2]
-        print(first_comma_node.text)
+        self.assertEqual(first_comma_node.text, b',')
 
         child_list_node = list_node.children[3]
-        print(child_list_node.text)
+        self.assertEqual(child_list_node.text, b'[1, 2, 3]')
 
         close_delim_node = list_node.children[4]
-        print(close_delim_node.text)
+        self.assertEqual(close_delim_node.text, b']')
+
+        edit_offset = len(b"[0, [")
+        tree.edit(
+            start_byte=edit_offset,
+            old_end_byte=edit_offset,
+            new_end_byte=edit_offset + 2,
+            start_point=(0, edit_offset),
+            old_end_point=(0, edit_offset),
+            new_end_point=(0, edit_offset + 2),
+        )
+        self.assertEqual(tree.text, None)
+
+        root_node_again = tree.root_node
+        self.assertEqual(root_node_again.text, None)
 
     def test_tree(self):
         code = b"def foo():\n  bar()\n\ndef foo():\n  bar()"

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -258,17 +258,23 @@ static PyObject *node_get_text(Node *self, void *payload) {
     Py_RETURN_NONE;
   }
   // "hello"[1:3] == "hello".__getitem__(slice(1, 3))
-  PyObject *slice = PySlice_New(PyLong_FromSize_t((size_t)ts_node_start_byte(self->node)),
-                                PyLong_FromSize_t((size_t)ts_node_end_byte(self->node)),
-                                NULL);
+  PyObject *slice =
+    PySlice_New(PyLong_FromSize_t((size_t)ts_node_start_byte(self->node)),
+                PyLong_FromSize_t((size_t)ts_node_end_byte(self->node)),
+                NULL);
   if (slice == Py_None) {
     Py_RETURN_NONE;
   }
-  PyObject *node_bytes = PyObject_GetItem(source, slice);
-  if (node_bytes == Py_None) {
+  PyObject *node_mv = PyMemoryView_FromObject(source);
+  if (node_mv == Py_None) {
     Py_RETURN_NONE;
   }
-  return node_bytes;
+  PyObject *node_slice = PyObject_GetItem(node_mv, slice);
+  if (node_slice == Py_None) {
+    Py_RETURN_NONE;
+  }
+  Py_INCREF(node_slice);
+  return node_slice;
 }
 
 static PyMethodDef node_methods[] = {


### PR DESCRIPTION
This is an initial attempt to address: https://github.com/tree-sitter/py-tree-sitter/issues/36, i.e. the ability to access the text of a node via `.text`.

I believe the approach is more-or-less similar to what node-tree-sitter does, though somewhat less sophisticated.

In order to avoid being misleading, the `.text` implemented here returns `None` if the tree has been edited.  So `.text` is only meant to work as long as `.edit` has not yet been called for a tree.

There are also some tests for the basic `.text` functionality as well as confirming that calling `.text` after a call to `.edit` yields `None`.