### PR TITLE
Named children

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -176,6 +176,8 @@ class TestNode(TestCase):
         self.assertEqual(list_node.parent,
                          exp_stmt_node)
 
+        named_children = list_node.named_children
+
         open_delim_node = list_node.children[0]
         self.assertEqual(open_delim_node.type, "[")
         self.assertEqual(open_delim_node.start_byte, 0)
@@ -190,6 +192,8 @@ class TestNode(TestCase):
                          open_delim_node.next_named_sibling)
         self.assertEqual(first_num_node.parent,
                          list_node)
+        self.assertEqual(named_children[0],
+                         first_num_node)
 
         first_comma_node = list_node.children[2]
         self.assertEqual(first_comma_node,
@@ -208,6 +212,8 @@ class TestNode(TestCase):
                          second_num_node.prev_named_sibling)
         self.assertEqual(second_num_node.parent,
                          list_node)
+        self.assertEqual(named_children[1],
+                         second_num_node)
 
         second_comma_node = list_node.children[4]
         self.assertEqual(second_comma_node,
@@ -226,6 +232,8 @@ class TestNode(TestCase):
                          third_num_node.prev_named_sibling)
         self.assertEqual(third_num_node.parent,
                          list_node)
+        self.assertEqual(named_children[2],
+                         third_num_node)
 
         close_delim_node = list_node.children[6]
         self.assertEqual(close_delim_node.type, "]")

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -226,6 +226,32 @@ static PyObject *node_get_children(Node *self, void *payload) {
   return result;
 }
 
+static PyObject *node_get_named_children(Node *self, void *payload) {
+  long length = (long)ts_node_child_count(self->node);
+  PyObject *result = PyList_New(length);
+  if (result == NULL) {
+    Py_RETURN_NONE;
+  }
+  if (length > 0) {
+    ts_tree_cursor_reset(&default_cursor, self->node);
+    ts_tree_cursor_goto_first_child(&default_cursor);
+    int i = 0;
+    do {
+      TSNode child = ts_tree_cursor_current_node(&default_cursor);
+      if (ts_node_is_named(child)) {
+        if (-1 == PyList_SetItem(result, i,
+                                 node_new_internal(child, self->tree)))
+        {
+          Py_RETURN_NONE;
+        }
+        i++;
+      }
+    } while (ts_tree_cursor_goto_next_sibling(&default_cursor));
+  }
+  Py_INCREF(result);
+  return result;
+}
+
 static PyObject *node_get_child_count(Node *self, void *payload) {
   long length = (long)ts_node_child_count(self->node);
   PyObject *result = PyLong_FromLong(length);
@@ -374,6 +400,7 @@ static PyGetSetDef node_accessors[] = {
   {"end_point", (getter)node_get_end_point, NULL, "The node's end point", NULL},
   {"children", (getter)node_get_children, NULL, "The node's children", NULL},
   {"child_count", (getter)node_get_child_count, NULL, "The number of children for a node", NULL},
+  {"named_children", (getter)node_get_named_children, NULL, "The node's named children", NULL},
   {"named_child_count", (getter)node_get_named_child_count, NULL, "The number of named children for a node", NULL},
   {"next_sibling", (getter)node_get_next_sibling, NULL, "The node's next sibling", NULL},
   {"prev_sibling", (getter)node_get_prev_sibling, NULL, "The node's previous sibling", NULL},

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -211,13 +211,20 @@ static PyObject *node_get_children(Node *self, void *payload) {
 
   long length = (long)ts_node_child_count(self->node);
   PyObject *result = PyList_New(length);
+  if (result == NULL) {
+    Py_RETURN_NONE;
+  }
   if (length > 0) {
     ts_tree_cursor_reset(&default_cursor, self->node);
     ts_tree_cursor_goto_first_child(&default_cursor);
     int i = 0;
     do {
       TSNode child = ts_tree_cursor_current_node(&default_cursor);
-      PyList_SetItem(result, i, node_new_internal(child, self->tree));
+      if (-1 == PyList_SetItem(result, i,
+                               node_new_internal(child, self->tree)))
+      {
+        Py_RETURN_NONE;
+      }
       i++;
     } while (ts_tree_cursor_goto_next_sibling(&default_cursor));
   }

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -212,7 +212,6 @@ static PyObject *node_get_children(Node *self, void *payload) {
   long length = (long)ts_node_child_count(self->node);
   PyObject *result = PyList_New(length);
   if (result == NULL) {
-    PyErr_SetString(PyExc_RuntimeError, "PyList_New failed");
     return NULL;
   }
   if (length > 0) {
@@ -221,10 +220,8 @@ static PyObject *node_get_children(Node *self, void *payload) {
     int i = 0;
     do {
       TSNode child = ts_tree_cursor_current_node(&default_cursor);
-      if (-1 == PyList_SetItem(result, i,
-                               node_new_internal(child, self->tree)))
-      {
-        PyErr_SetString(PyExc_RuntimeError, "PyList_SetItem failed");
+      if (PyList_SetItem(result, i, node_new_internal(child, self->tree))) {
+        Py_DECREF(result);
         return NULL;
       }
       i++;
@@ -238,28 +235,29 @@ static PyObject *node_get_children(Node *self, void *payload) {
 static PyObject *node_get_named_children(Node *self, void *payload) {
   PyObject* children = node_get_children(self, payload);
   if (children == NULL) {
-    PyErr_SetString(PyExc_ValueError, "Failed to get node's children");
     return NULL;
   }
+  // children is retained by self->children
   Py_DECREF(children);
 
-  PyObject *result = PyList_New(0);
+  long named_count = (long)ts_node_named_child_count(self->node);
+  PyObject *result = PyList_New(named_count);
   if (result == NULL) {
-    PyErr_SetString(PyExc_RuntimeError, "PyList_new failed");
     return NULL;
   }
 
   long length = (long)ts_node_child_count(self->node);
+  int j = 0;
   for (int i = 0; i < length; i++) {
-    Node *child = (Node *) PyList_GetItem(self->children, i);
-    if (ts_node_is_named(child->node)) {
-      if (-1 == PyList_Append(result, (PyObject *) child)) {
-        PyErr_SetString(PyExc_RuntimeError, "PyList_SetItem failed");
+    PyObject *child = PyList_GetItem(self->children, i);
+    if (ts_node_is_named(((Node *)child)->node)) {
+      Py_INCREF(child);
+      if (PyList_SetItem(result, j++, child)) {
+        Py_DECREF(result);
         return NULL;
       }
     }
   }
-  Py_INCREF(result);
   return result;
 }
 


### PR DESCRIPTION
This PR includes:

* an attempt to add a `named_children` binding
* some associated tests
* some tweaks to `node_get_children` regarding checking of some return values

<s>Unlike `node_get_children`, `node_get_named_children` doesn't check or interact with the "cache" of `children`: https://github.com/tree-sitter/py-tree-sitter/blob/323d2bb0e26d7b9ac816b562fb38cbec9138ff18/tree_sitter/binding.c#L11 within `Node`.  I suppose it could...</s>

See update below.