### PR TITLE
Fix leaks in node_get_*child_count

### DIFF
--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -192,14 +192,12 @@ static PyObject *node_get_children(Node *self, void *payload) {
 static PyObject *node_get_child_count(Node *self, void *payload) {
   long length = (long)ts_node_child_count(self->node);
   PyObject *result = PyLong_FromLong(length);
-  Py_INCREF(result);
   return result;
 }
 
 static PyObject *node_get_named_child_count(Node *self, void *payload) {
   long length = (long)ts_node_named_child_count(self->node);
   PyObject *result = PyLong_FromLong(length);
-  Py_INCREF(result);
   return result;
 }
 


### PR DESCRIPTION
Sorry, I think I introduced some leaks in https://github.com/tree-sitter/py-tree-sitter/commit/4fd0d9269c4802aa2949d410f318b1139868d8d0 in the two `node_get_*child_count` implementations.

I checked using a debug build of python and observed the reported refcounts in a python session started with `python -X showrefcount`:

Before the current PR:
```
[219100 refs, 0 blocks]
>>> list_node = exp_stmt_node.children[0]
[219107 refs, 0 blocks]
>>> list_node.child_count
7
[219108 refs, 0 blocks]
>>> list_node.child_count
7
[219109 refs, 0 blocks]
>>> list_node.child_count
7
[219110 refs, 0 blocks]
>>> list_node.child_count
7
[219111 refs, 0 blocks]
```
So the refcount has increased after `list_node.child_count` and keeps increasing.

With the changes in this PR:
```
[219096 refs, 0 blocks]
>>> list_node = exp_stmt_node.children[0]
[219103 refs, 0 blocks]
>>> list_node.child_count
7
[219103 refs, 0 blocks]
>>> list_node.child_count
7
[219103 refs, 0 blocks]
>>> list_node.child_count
7
[219103 refs, 0 blocks]
>>> list_node.child_count
7
[219103 refs, 0 blocks]
```

The refcount isn't changing.