### PR TITLE
Add a pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=43.0.0",
+    "wheel>=0.36.2",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Explicitly declares that this project uses setuptools to build
itself.

Modern versions of pip will warn for packages that don't declare
what the expected way to build them is.

(The version of wheel pinned from below here is simply to avoid
a macOS 11 bug in wheel).