### PR TITLE
Fix use after free of `Query.capture_names` elements

### DIFF
--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -709,8 +709,10 @@ static PyObject *query_captures(Query *self, PyObject *args, PyObject *kwargs) {
     const TSQueryCapture *capture = &match.captures[capture_index];
     PyObject *capture_node = node_new_internal(capture->node, node->tree);
     PyObject *capture_name = PyList_GetItem(self->capture_names, capture->index);
-    PyList_Append(result, PyTuple_Pack(2, capture_node, capture_name));
+    PyObject *item = PyTuple_Pack(2, capture_node, capture_name);
     Py_XDECREF(capture_node);
+    PyList_Append(result, item);
+    Py_XDECREF(item);
   }
 
   return result;

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -711,7 +711,6 @@ static PyObject *query_captures(Query *self, PyObject *args, PyObject *kwargs) {
     PyObject *capture_name = PyList_GetItem(self->capture_names, capture->index);
     PyList_Append(result, PyTuple_Pack(2, capture_node, capture_name));
     Py_XDECREF(capture_node);
-    Py_XDECREF(capture_name);
   }
 
   return result;


### PR DESCRIPTION
`PyList_GetItem` returns a borrowed reference to the list element that
is then passed to `PyTuple_Pack`, which increments its reference count
and stores that reference in the tuple. Calling `Py_XDECREF` on the
reference therefore leaves the refcount one too low.

<details><summary>Run of test suite on commit 36536ed23169ecb7ace1497d2eca01db12e211fb</summary>

This uses CPython v3.9.1 compiled with `--with-assertions --with-address-sanitizer --with-undefined-behavior-sanitizer --with-valgrind --with-pydebug --enable-shared`, but it also affects the CPython interpreter from the Arch repos (also v3.9.1).

```
============================================================ test session starts ============================================================
platform linux -- Python 3.9.1, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /tmp/py-tree-sitter
collected 11 items

tests/test_tree_sitter.py ...........                                                                                                 [100%]

============================================================ 11 passed in 5.65s =============================================================
=================================================================
==117070==ERROR: AddressSanitizer: heap-use-after-free on address 0x6080024a23b8 at pc 0x7efcd7e027a9 bp 0x7ffead450ae0 sp 0x7ffead450ad0
READ of size 8 at 0x6080024a23b8 thread T0
    #0 0x7efcd7e027a8 in _PyObject_IsFreed Objects/object.c:329
    #1 0x7efcd83a2866 in visit_decref Modules/gcmodule.c:441
    #2 0x7efcd7e545e4 in tupletraverse Objects/tupleobject.c:624
    #3 0x7efcd839b404 in subtract_refs Modules/gcmodule.c:469
    #4 0x7efcd83a694f in deduce_unreachable Modules/gcmodule.c:1092
    #5 0x7efcd83a694f in collect Modules/gcmodule.c:1212
    #6 0x7efcd83a7ad2 in collect_with_callback Modules/gcmodule.c:1387
    #7 0x7efcd83aa6ac in PyGC_Collect Modules/gcmodule.c:2063
    #8 0x7efcd83aa7e2 in _PyGC_CollectIfEnabled Modules/gcmodule.c:2074
    #9 0x7efcd82e9b69 in Py_FinalizeEx Python/pylifecycle.c:1423
    #10 0x7efcd82eacdf in Py_Exit Python/pylifecycle.c:2433
    #11 0x7efcd8304d7a in handle_system_exit Python/pythonrun.c:696
    #12 0x7efcd8305766 in _PyErr_PrintEx Python/pythonrun.c:706
    #13 0x7efcd83070bf in PyErr_PrintEx Python/pythonrun.c:801
    #14 0x7efcd8307107 in PyErr_Print Python/pythonrun.c:807
    #15 0x7efcd830c6d8 in PyRun_SimpleFileExFlags Python/pythonrun.c:444
    #16 0x7efcd830c9be in PyRun_AnyFileExFlags Python/pythonrun.c:87
    #17 0x7efcd83977df in pymain_run_file Modules/main.c:373
    #18 0x7efcd839a57c in pymain_run_python Modules/main.c:598
    #19 0x7efcd839a804 in Py_RunMain Modules/main.c:677
    #20 0x7efcd839a9fa in pymain_main Modules/main.c:707
    #21 0x7efcd839ad5f in Py_BytesMain Modules/main.c:731
    #22 0x5607958fe161 in main Programs/python.c:15
    #23 0x7efcd591eb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    #24 0x5607958fe08d in _start (/tmp/pythonprefix/bin/python3.9+0x108d)

0x6080024a23b8 is located 24 bytes inside of 81-byte region [0x6080024a23a0,0x6080024a23f1)
freed by thread T0 here:
    #0 0x7efcd9f6e0e9 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:123
    #1 0x7efcd7e15c77 in _PyMem_RawFree Objects/obmalloc.c:127
    #2 0x7efcd7e1748c in _PyMem_DebugRawFree Objects/obmalloc.c:2212
    #3 0x7efcd7e1837c in _PyMem_DebugFree Objects/obmalloc.c:2345
    #4 0x7efcd7e1a1c2 in PyObject_Free Objects/obmalloc.c:709
    #5 0x7efcd7ef779c in unicode_dealloc Objects/unicodeobject.c:1966
    #6 0x7efcd7e070a1 in _Py_Dealloc Objects/object.c:2209
    #7 0x7efcd7d1d8da in _Py_DECREF Include/object.h:430
    #8 0x7efcd7d1d8da in _Py_XDECREF Include/object.h:497
    #9 0x7efcd7d1d8da in list_dealloc Objects/listobject.c:336
    #10 0x7efcd7e070a1 in _Py_Dealloc Objects/object.c:2209
    #11 0x7efcd0194046 in _Py_DECREF /tmp/pythonprefix/include/python3.9d/object.h:430
    #12 0x7efcd0194046 in _Py_XDECREF /tmp/pythonprefix/include/python3.9d/object.h:497
    #13 0x7efcd0194046 in query_dealloc tree_sitter/binding.c:722
    #14 0x7efcd7e070a1 in _Py_Dealloc Objects/object.c:2209
    #15 0x7efcd7cfc7de in _Py_DECREF Include/object.h:430
    #16 0x7efcd7cfc7de in frame_dealloc Objects/frameobject.c:580
    #17 0x7efcd7e070a1 in _Py_Dealloc Objects/object.c:2209
    #18 0x7efcd7c4b51c in _Py_DECREF Include/object.h:430
    #19 0x7efcd7c4b51c in function_code_fastcall Objects/call.c:337
    #20 0x7efcd7c4d9ba in _PyFunction_Vectorcall Objects/call.c:366
    #21 0x7efcd7c59e8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #22 0x7efcd7c5cb62 in method_vectorcall Objects/classobject.c:53
    #23 0x7efcd81b9ab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #24 0x7efcd81b9ab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #25 0x7efcd81b9ab5 in call_function Python/ceval.c:5072
    #26 0x7efcd81b9ab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #27 0x7efcd7c4abe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #28 0x7efcd7c4abe0 in function_code_fastcall Objects/call.c:329
    #29 0x7efcd7c4d9ba in _PyFunction_Vectorcall Objects/call.c:366
    #30 0x7efcd81b9054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #31 0x7efcd81b9054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #32 0x7efcd81b9054 in call_function Python/ceval.c:5072
    #33 0x7efcd81b9054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #34 0x7efcd81c6df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #35 0x7efcd81c6df1 in _PyEval_EvalCode Python/ceval.c:4327
    #36 0x7efcd7c4ddf7 in _PyFunction_Vectorcall Objects/call.c:395
    #37 0x7efcd7c59e8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #38 0x7efcd7c5cb62 in method_vectorcall Objects/classobject.c:53
    #39 0x7efcd7c4be65 in PyVectorcall_Call Objects/call.c:242
    #40 0x7efcd7c4ca90 in _PyObject_Call Objects/call.c:265
    #41 0x7efcd7c4cddb in PyObject_Call Objects/call.c:292
    #42 0x7efcd81724e9 in do_call_core Python/ceval.c:5120
    #43 0x7efcd81bb7ba in _PyEval_EvalFrameDefault Python/ceval.c:3580

previously allocated by thread T0 here:
    #0 0x7efcd9f6e459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7efcd7e15ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7efcd7e16117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7efcd7e1622a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7efcd7e183ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7efcd7e1a147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7efcd7f1dbbb in PyUnicode_New Objects/unicodeobject.c:1446
    #7 0x7efcd7ff1611 in unicode_decode_utf8 Objects/unicodeobject.c:5005
    #8 0x7efcd7ff37f6 in PyUnicode_DecodeUTF8Stateful Objects/unicodeobject.c:5135
    #9 0x7efcd7ff3815 in PyUnicode_FromStringAndSize Objects/unicodeobject.c:2267
    #10 0x7efcd01947e6 in query_new_internal tree_sitter/binding.c:801
    #11 0x7efcd0194a2f in language_query tree_sitter/binding.c:838
    #12 0x7efcd7def6c0 in cfunction_call Objects/methodobject.c:548
    #13 0x7efcd7c4ed1b in _PyObject_MakeTpCall Objects/call.c:191
    #14 0x7efcd81b9b10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #15 0x7efcd81b9b10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #16 0x7efcd81b9b10 in call_function Python/ceval.c:5072
    #17 0x7efcd81b9b10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #18 0x7efcd7c4abe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #19 0x7efcd7c4abe0 in function_code_fastcall Objects/call.c:329
    #20 0x7efcd7c4d9ba in _PyFunction_Vectorcall Objects/call.c:366
    #21 0x7efcd81b9054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #22 0x7efcd81b9054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #23 0x7efcd81b9054 in call_function Python/ceval.c:5072
    #24 0x7efcd81b9054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #25 0x7efcd7c4abe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #26 0x7efcd7c4abe0 in function_code_fastcall Objects/call.c:329
    #27 0x7efcd7c4d9ba in _PyFunction_Vectorcall Objects/call.c:366
    #28 0x7efcd7c59e8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #29 0x7efcd7c5cb62 in method_vectorcall Objects/classobject.c:53
    #30 0x7efcd81b9ab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #31 0x7efcd81b9ab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #32 0x7efcd81b9ab5 in call_function Python/ceval.c:5072
    #33 0x7efcd81b9ab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #34 0x7efcd7c4abe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #35 0x7efcd7c4abe0 in function_code_fastcall Objects/call.c:329
    #36 0x7efcd7c4d9ba in _PyFunction_Vectorcall Objects/call.c:366
    #37 0x7efcd81b9054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #38 0x7efcd81b9054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #39 0x7efcd81b9054 in call_function Python/ceval.c:5072
    #40 0x7efcd81b9054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #41 0x7efcd81c6df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #42 0x7efcd81c6df1 in _PyEval_EvalCode Python/ceval.c:4327
    #43 0x7efcd7c4ddf7 in _PyFunction_Vectorcall Objects/call.c:395
    #44 0x7efcd7c59e8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #45 0x7efcd7c5cb62 in method_vectorcall Objects/classobject.c:53

SUMMARY: AddressSanitizer: heap-use-after-free Objects/object.c:329 in _PyObject_IsFreed
Shadow bytes around the buggy address:
  0x0c108048c420: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c108048c430: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c108048c440: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c108048c450: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c108048c460: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c108048c470: fa fa fa fa fd fd fd[fd]fd fd fd fd fd fd fd fa
  0x0c108048c480: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c108048c490: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c108048c4a0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c108048c4b0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c108048c4c0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==117070==ABORTING
```

</details>


<details><summary>Run of test suite with fix</summary>

```
============================================================ test session starts ============================================================
platform linux -- Python 3.9.1, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /tmp/py-tree-sitter
collected 11 items

tests/test_tree_sitter.py ...........                                                                                                 [100%]

============================================================ 11 passed in 5.63s =============================================================

=================================================================
==117638==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 480 byte(s) in 6 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23bccf9 in PyTuple_New Objects/tupleobject.c:110
    #11 0x7f88a2705a48 in _PyEval_EvalFrameDefault Python/ceval.c:2741
    #12 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #13 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #14 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #15 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #16 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #17 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #18 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #19 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #20 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #21 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #22 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #23 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #24 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #25 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #26 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #27 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #28 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #29 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #30 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #31 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #32 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #33 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #34 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #35 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #36 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #37 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #38 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #39 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #40 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #41 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #42 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #43 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #44 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #45 0x7f88a271b561 in call_function Python/ceval.c:5072
    #46 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #47 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #48 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #49 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395

Direct leak of 112 byte(s) in 2 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a22a5f72 in _PyLong_New Objects/longobject.c:259
    #7 0x7f88a22c0a42 in PyLong_FromUnsignedLong Objects/longobject.c:395
    #8 0x7f88a22c71bd in PyLong_FromVoidPtr Objects/longobject.c:1094
    #9 0x7f889aa5197b in P_get /tmp/cpython/Modules/_ctypes/cfield.c:1503
    #10 0x7f889aa4685a in GetResult /tmp/cpython/Modules/_ctypes/callproc.c:996
    #11 0x7f889aa4d78f in _ctypes_callproc /tmp/cpython/Modules/_ctypes/callproc.c:1314
    #12 0x7f889aa24ce5 in PyCFuncPtr_call /tmp/cpython/Modules/_ctypes/_ctypes.c:4201
    #13 0x7f88a21b1d1b in _PyObject_MakeTpCall Objects/call.c:191
    #14 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #15 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #16 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #17 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #18 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #19 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #20 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #21 0x7f88a21b32fd in _PyObject_FastCallDictTstate Objects/call.c:118
    #22 0x7f88a21b3dcf in _PyObject_Call_Prepend Objects/call.c:488
    #23 0x7f88a240ee04 in slot_tp_init Objects/typeobject.c:6943
    #24 0x7f88a23fd143 in type_call Objects/typeobject.c:1026
    #25 0x7f88a21b1d1b in _PyObject_MakeTpCall Objects/call.c:191
    #26 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #27 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #28 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #29 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #30 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #31 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #32 0x7f88a272a8d9 in _PyEval_EvalCodeWithName Python/ceval.c:4359
    #33 0x7f88a272a98f in PyEval_EvalCodeEx Python/ceval.c:4375
    #34 0x7f88a272a9dc in PyEval_EvalCode Python/ceval.c:826
    #35 0x7f88a26b1c89 in builtin_exec_impl Python/bltinmodule.c:1035
    #36 0x7f88a26b211e in builtin_exec Python/clinic/bltinmodule.c.h:396
    #37 0x7f88a2355e8f in cfunction_vectorcall_FASTCALL Objects/methodobject.c:426

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a21b1613 in _PyObject_MakeTpCall Objects/call.c:165
    #12 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #13 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #14 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #15 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #16 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #17 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #18 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #19 0x7f88a240b317 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a240b317 in vectorcall_unbound Objects/typeobject.c:1505
    #21 0x7f88a240b317 in vectorcall_method Objects/typeobject.c:1537
    #22 0x7f88a240c18f in slot_mp_subscript Objects/typeobject.c:6467
    #23 0x7f88a211a729 in PyObject_GetItem Objects/abstract.c:157
    #24 0x7f88a26e7687 in _PyEval_EvalFrameDefault Python/ceval.c:1725
    #25 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #26 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #27 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #28 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #29 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #30 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #31 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #32 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #33 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #34 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #35 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #36 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #37 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #38 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #39 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #40 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #41 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #42 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #43 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #44 0x7f88a271b561 in call_function Python/ceval.c:5072
    #45 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #46 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #47 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a21b1613 in _PyObject_MakeTpCall Objects/call.c:165
    #12 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #13 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #14 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #15 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #16 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #17 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #18 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #19 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #21 0x7f88a271b561 in call_function Python/ceval.c:5072
    #22 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #23 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #24 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #25 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #26 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #27 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #28 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #29 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #30 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #31 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #32 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #33 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #34 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #35 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #36 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #37 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #38 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #39 0x7f88a272a8d9 in _PyEval_EvalCodeWithName Python/ceval.c:4359
    #40 0x7f88a272a98f in PyEval_EvalCodeEx Python/ceval.c:4375
    #41 0x7f88a272a9dc in PyEval_EvalCode Python/ceval.c:826
    #42 0x7f88a26b1c89 in builtin_exec_impl Python/bltinmodule.c:1035
    #43 0x7f88a26b211e in builtin_exec Python/clinic/bltinmodule.c.h:396
    #44 0x7f88a2355e8f in cfunction_vectorcall_FASTCALL Objects/methodobject.c:426

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a21b1613 in _PyObject_MakeTpCall Objects/call.c:165
    #12 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #13 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #14 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #15 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #16 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #17 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #18 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #19 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #21 0x7f88a271c054 in call_function Python/ceval.c:5072
    #22 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #23 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #24 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #25 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #26 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #27 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #28 0x7f88a271c054 in call_function Python/ceval.c:5072
    #29 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #30 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #31 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #32 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #33 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #34 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #35 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #36 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #37 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #38 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #39 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #40 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #41 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #42 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #43 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #44 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #45 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #46 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #47 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #48 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #49 0x7f88a271b561 in call_function Python/ceval.c:5072
    #50 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #51 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #52 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a21b1613 in _PyObject_MakeTpCall Objects/call.c:165
    #12 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #13 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #14 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #15 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #16 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #17 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #18 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #19 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #21 0x7f88a271c054 in call_function Python/ceval.c:5072
    #22 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #23 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #24 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #25 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #26 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #27 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #28 0x7f88a271c054 in call_function Python/ceval.c:5072
    #29 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #30 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #31 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #32 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #33 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #34 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #35 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #36 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #37 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #38 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #39 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #40 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #41 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #42 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #43 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #44 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #45 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #46 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #47 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #48 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #49 0x7f88a271b561 in call_function Python/ceval.c:5072
    #50 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #51 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #52 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a2726964 in _PyEval_EvalCode Python/ceval.c:4138
    #12 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #13 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #14 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #15 0x7f88a271b561 in call_function Python/ceval.c:5072
    #16 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #17 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #18 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #19 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #20 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #21 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #22 0x7f88a271c054 in call_function Python/ceval.c:5072
    #23 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #24 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #25 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #26 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #27 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #28 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #29 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #30 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #31 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #32 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #33 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #34 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #35 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #36 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #37 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #38 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #39 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #40 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #41 0x7f88a21b49e3 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #42 0x7f88a21b49e3 in object_vacall Objects/call.c:791
    #43 0x7f88a21b521c in _PyObject_CallMethodIdObjArgs Objects/call.c:882
    #44 0x7f88a27d88ec in import_find_and_load Python/import.c:1771
    #45 0x7f88a27ea26e in PyImport_ImportModuleLevelObject Python/import.c:1872

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a21b1613 in _PyObject_MakeTpCall Objects/call.c:165
    #12 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #13 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #14 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #15 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #16 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #17 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #18 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #19 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #21 0x7f88a271c054 in call_function Python/ceval.c:5072
    #22 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #23 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #24 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #25 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #26 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #27 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #28 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #29 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #30 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #31 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #32 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #33 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #34 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #35 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #36 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #37 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #38 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #39 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #40 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #41 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #42 0x7f88a271b561 in call_function Python/ceval.c:5072
    #43 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #44 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #45 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #46 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #47 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #48 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #49 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #50 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #51 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #52 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d183a in __interceptor_realloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x7f88a2378ca0 in _PyMem_RawRealloc Objects/obmalloc.c:121
    #2 0x7f88a237a796 in _PyMem_DebugRawRealloc Objects/obmalloc.c:2265
    #3 0x7f88a237b404 in _PyMem_DebugRealloc Objects/obmalloc.c:2353
    #4 0x7f88a237d1a6 in PyObject_Realloc Objects/obmalloc.c:703
    #5 0x7f88a290fdb7 in _PyObject_GC_Resize Modules/gcmodule.c:2297
    #6 0x7f88a23c43e2 in _PyTuple_Resize Objects/tupleobject.c:944
    #7 0x7f88a212080c in PySequence_Tuple Objects/abstract.c:1979
    #8 0x7f88a23bd37b in tuple_new_impl Objects/tupleobject.c:708
    #9 0x7f88a23be2d5 in tuple_vectorcall Objects/tupleobject.c:725
    #10 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #11 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #12 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #13 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #14 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #15 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #16 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #17 0x7f88a26c3582 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #18 0x7f88a271b561 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #19 0x7f88a271b561 in call_function Python/ceval.c:5072
    #20 0x7f88a271b561 in _PyEval_EvalFrameDefault Python/ceval.c:3487
    #21 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #22 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #23 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #24 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #25 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #26 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #27 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #28 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #29 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #30 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #31 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #32 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #33 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #34 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #35 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #36 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #37 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #38 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #39 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #40 0x7f88a271c054 in call_function Python/ceval.c:5072
    #41 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #42 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #43 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #44 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #45 0x7f88a21bce8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #46 0x7f88a21bf950 in method_vectorcall Objects/classobject.c:83
    #47 0x7f88a21af15a in PyVectorcall_Call Objects/call.c:230
    #48 0x7f88a21afa90 in _PyObject_Call Objects/call.c:265

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a290b46f in _PyObject_GC_Alloc Modules/gcmodule.c:2225
    #7 0x7f88a290f668 in _PyObject_GC_Malloc Modules/gcmodule.c:2252
    #8 0x7f88a290f977 in _PyObject_GC_NewVar Modules/gcmodule.c:2281
    #9 0x7f88a23b7a93 in tuple_alloc Objects/tupleobject.c:92
    #10 0x7f88a23c2c8e in _PyTuple_FromArray Objects/tupleobject.c:420
    #11 0x7f88a21b1613 in _PyObject_MakeTpCall Objects/call.c:165
    #12 0x7f88a271cb10 in _PyObject_VectorcallTstate Include/cpython/abstract.h:116
    #13 0x7f88a271cb10 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #14 0x7f88a271cb10 in call_function Python/ceval.c:5072
    #15 0x7f88a271cb10 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #16 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #17 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #18 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #19 0x7f88a240b317 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a240b317 in vectorcall_unbound Objects/typeobject.c:1505
    #21 0x7f88a240b317 in vectorcall_method Objects/typeobject.c:1537
    #22 0x7f88a240c18f in slot_mp_subscript Objects/typeobject.c:6467
    #23 0x7f88a211a729 in PyObject_GetItem Objects/abstract.c:157
    #24 0x7f88a26e7687 in _PyEval_EvalFrameDefault Python/ceval.c:1725
    #25 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #26 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #27 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #28 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #29 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #30 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #31 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #32 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #33 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #34 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #35 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #36 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #37 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #38 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #39 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #40 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #41 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #42 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #43 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #44 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #45 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #46 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #47 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #48 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366

Indirect leak of 1232 byte(s) in 14 object(s) allocated from:
    #0 0x7f88a44d1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f88a2378ce3 in _PyMem_RawMalloc Objects/obmalloc.c:99
    #2 0x7f88a2379117 in _PyMem_DebugRawAlloc Objects/obmalloc.c:2145
    #3 0x7f88a237922a in _PyMem_DebugRawMalloc Objects/obmalloc.c:2178
    #4 0x7f88a237b3ba in _PyMem_DebugMalloc Objects/obmalloc.c:2330
    #5 0x7f88a237d147 in PyObject_Malloc Objects/obmalloc.c:685
    #6 0x7f88a240153f in PyType_GenericAlloc Objects/typeobject.c:1050
    #7 0x7f889a6f23a9 in node_new_internal tree_sitter/binding.c:316
    #8 0x7f889a6f7948 in query_captures tree_sitter/binding.c:710
    #9 0x7f88a21ec027 in method_vectorcall_VARARGS_KEYWORDS Objects/descrobject.c:346
    #10 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #11 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #12 0x7f88a271c054 in call_function Python/ceval.c:5072
    #13 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #14 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #15 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #16 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #17 0x7f88a21bce8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #18 0x7f88a21bfb62 in method_vectorcall Objects/classobject.c:53
    #19 0x7f88a271cab5 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #20 0x7f88a271cab5 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #21 0x7f88a271cab5 in call_function Python/ceval.c:5072
    #22 0x7f88a271cab5 in _PyEval_EvalFrameDefault Python/ceval.c:3518
    #23 0x7f88a21adbe0 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #24 0x7f88a21adbe0 in function_code_fastcall Objects/call.c:329
    #25 0x7f88a21b09ba in _PyFunction_Vectorcall Objects/call.c:366
    #26 0x7f88a271c054 in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #27 0x7f88a271c054 in PyObject_Vectorcall Include/cpython/abstract.h:127
    #28 0x7f88a271c054 in call_function Python/ceval.c:5072
    #29 0x7f88a271c054 in _PyEval_EvalFrameDefault Python/ceval.c:3504
    #30 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #31 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #32 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395
    #33 0x7f88a21bce8d in _PyObject_VectorcallTstate Include/cpython/abstract.h:118
    #34 0x7f88a21bfb62 in method_vectorcall Objects/classobject.c:53
    #35 0x7f88a21aee65 in PyVectorcall_Call Objects/call.c:242
    #36 0x7f88a21afa90 in _PyObject_Call Objects/call.c:265
    #37 0x7f88a21afddb in PyObject_Call Objects/call.c:292
    #38 0x7f88a26d54e9 in do_call_core Python/ceval.c:5120
    #39 0x7f88a271e7ba in _PyEval_EvalFrameDefault Python/ceval.c:3580
    #40 0x7f88a2729df1 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:40
    #41 0x7f88a2729df1 in _PyEval_EvalCode Python/ceval.c:4327
    #42 0x7f88a21b0df7 in _PyFunction_Vectorcall Objects/call.c:395

SUMMARY: AddressSanitizer: 2464 byte(s) leaked in 30 allocation(s).
```

</details>

Note that AddressSanitizer reports a memory leak. I believe this is due to the fact that the tuple that is created [here](https://github.com/tree-sitter/py-tree-sitter/blob/36536ed23169ecb7ace1497d2eca01db12e211fb/tree_sitter/binding.c#L712) is never decref’d.