### PR TITLE
add support for TSInput-style parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,42 @@ def foo():
 """, "utf8"))
 ```
 
+If you have your source code in some data structure other than a bytes object,
+you can pass a "read" callable to the parse function.
+
+The read callable can use either the byte offset or point tuple to read from
+buffer and return source code as bytes object. An empty bytes object or None
+terminates parsing for that line. The bytes must encode the source as UTF-8.
+
+For example, to use the byte offset:
+
+```python
+src = bytes("""
+def foo():
+    if bar:
+        baz()
+""", "utf8")
+
+def read_callable(byte_offset, point):
+    return src[byte_offset:byte_offset+1]
+
+tree = parser.parse(read_callable)
+```
+
+And to use the point:
+
+```python
+src_lines = ["def foo():\n", "    if bar:\n", "        baz()"]
+
+def read_callable(byte_offset, point):
+    row, column = point
+    if row >= len(src_lines) or column >= len(src_lines[row]):
+        return None
+    return src_lines[row][column:].encode('utf8')
+
+tree = parser.parse(read_callable)
+```
+
 Inspect the resulting `Tree`:
 
 ```python

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -772,42 +772,116 @@ static void parser_dealloc(Parser *self) {
   Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static PyObject *parser_parse(Parser *self, PyObject *args, PyObject *kwargs) {
-  PyObject *source_code = NULL;
-  PyObject *old_tree_arg = NULL;
-  int keep_text = 1;
-  static char *keywords[] = {"source", "old_tree", "keep_text", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Op:parse", keywords, &source_code, &old_tree_arg, &keep_text)) {
+typedef struct {
+  PyObject *read_cb;
+  PyObject *previous_return_value;
+} ReadWrapperPayload;
+
+static const char* parser_read_wrapper(void *payload, uint32_t byte_offset, TSPoint position, uint32_t* bytes_read) {
+  ReadWrapperPayload *wrapper_payload = payload;
+  PyObject *read_cb = wrapper_payload->read_cb;
+
+  // We assume that the parser only needs the return value until the next time
+  // this function is called or when ts_parser_parse() returns. We store the
+  // return value from the callable in wrapper_payload->previous_return_value so
+  // that its reference count will be decremented either during the next call to
+  // this wrapper or after ts_parser_parse() has returned.
+  Py_XDECREF(wrapper_payload->previous_return_value);
+  wrapper_payload->previous_return_value = NULL;
+
+  // Form arguments to callable.
+  PyObject *byte_offset_obj = PyLong_FromSize_t((size_t) byte_offset);
+  PyObject *position_obj = point_new(position);
+  if (!position_obj || !byte_offset_obj) {
+    *bytes_read = 0;
     return NULL;
   }
 
-  Py_buffer source_view;
-  if (PyObject_GetBuffer(source_code, &source_view, PyBUF_SIMPLE)) {
+  PyObject *args = PyTuple_Pack(2, byte_offset_obj, position_obj);
+  Py_XDECREF(byte_offset_obj);
+  Py_XDECREF(position_obj);
+
+  // Call callable.
+  PyObject* rv = PyObject_Call(read_cb, args, NULL);
+  Py_XDECREF(args);
+
+  // If error or None returned, we've done parsing.
+  if(!rv || (rv == Py_None)) {
+    Py_XDECREF(rv);
+    *bytes_read = 0;
+    return NULL;
+  }
+
+  // If something other than None is returned, it must be a bytes object.
+  if(!PyBytes_Check(rv)) {
+    Py_XDECREF(rv);
+    PyErr_SetString(PyExc_TypeError, "Read callable must return None or byte buffer type");
+    *bytes_read = 0;
+    return NULL;
+  }
+
+  // Store return value in payload so its reference count can be decremented and
+  // return string representation of bytes.
+  wrapper_payload->previous_return_value = rv;
+  *bytes_read = PyBytes_Size(rv);
+  return PyBytes_AsString(rv);
+}
+
+static PyObject *parser_parse(Parser *self, PyObject *args, PyObject *kwargs) {
+  PyObject *source_or_callback = NULL;
+  PyObject *old_tree_arg = NULL;
+  int keep_text = 1;
+  static char *keywords[] = {"", "old_tree", "keep_text", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Op:parse", keywords, &source_or_callback, &old_tree_arg, &keep_text)) {
     return NULL;
   }
 
   const TSTree *old_tree = NULL;
   if (old_tree_arg) {
     if (!PyObject_IsInstance(old_tree_arg, (PyObject *)&tree_type)) {
-      PyBuffer_Release(&source_view);
       PyErr_SetString(PyExc_TypeError, "Second argument to parse must be a Tree");
       return NULL;
     }
-
     old_tree = ((Tree *)old_tree_arg)->tree;
   }
 
-  const char *source_bytes = (const char *)source_view.buf;
-  size_t length = source_view.len;
-  TSTree *new_tree = ts_parser_parse_string(self->parser, old_tree, source_bytes, length);
-  PyBuffer_Release(&source_view);
+  TSTree *new_tree = NULL;
+  Py_buffer source_view;
+  if (! PyObject_GetBuffer(source_or_callback, &source_view, PyBUF_SIMPLE)) {
+    // parse a buffer
+    const char *source_bytes = (const char *)source_view.buf;
+    size_t length = source_view.len;
+    new_tree = ts_parser_parse_string(self->parser, old_tree, source_bytes, length);
+    PyBuffer_Release(&source_view);
+  } else if (PyCallable_Check(source_or_callback)) {
+    PyErr_Clear(); // clear the GetBuffer error
+    // parse a callable
+    ReadWrapperPayload payload = {
+      .read_cb = source_or_callback,
+      .previous_return_value = NULL,
+    };
+    TSInput input = {
+      .payload = &payload,
+      .read = parser_read_wrapper,
+      .encoding = TSInputEncodingUTF8,
+    };
+    new_tree = ts_parser_parse(self->parser, old_tree, input);
+    Py_XDECREF(payload.previous_return_value);
+
+    // don't allow tree_new_internal to keep the source text
+    source_or_callback = Py_None;
+    keep_text = 0;
+  } else {
+    PyErr_SetString(PyExc_TypeError, "First argument byte buffer type or callable");
+    return NULL;
+  }
 
   if (!new_tree) {
     PyErr_SetString(PyExc_ValueError, "Parsing failed");
     return NULL;
   }
 
-  return tree_new_internal(new_tree, source_code, keep_text);
+  return tree_new_internal(new_tree, source_or_callback, keep_text);
 }
 
 static PyObject *parser_set_language(Parser *self, PyObject *arg) {


### PR DESCRIPTION
Extend the Parser.parse() method to take a callable which acts like the
"read" callback from a TSInput struct. This callable takes the requested
byte offset and source location and returns a bytes object corresponding
to the source at that location. Returning an empty bytes object or None
terminates parsing for that line.

It is assumed that the parser only needs to "borrow" the return value
from the TSInput's read callback until the next call to the function or
when the ts_parser_parse() function returns. As such we use the
"payload" of the TSInput structure to record the last bytes object
returned so that its reference count may be decremented on the next call
to the read callback or when ts_parser_parse() returns.

Add some basic tests which demonstrate using the byte offset and TSPoint
arguments.