### PR TITLE
expose ts_tree_get_changed_ranges() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ new_tree = parser.parse(new_source, tree)
 
 This will run much faster than if you were parsing from scratch.
 
+The `Tree.get_changed_ranges` method can be called on the *old* tree to return
+the list of ranges whose syntactic structure has been changed:
+
+```python
+for changed_range in tree.get_changed_ranges(new_tree):
+    print('Changed range:')
+    print(f'  Start point {changed_range.start_point}')
+    print(f'  Start byte {changed_range.start_byte}')
+    print(f'  End point {changed_range.end_point}')
+    print(f'  End byte {changed_range.end_byte}')
+```
+
 #### Pattern-matching
 
 You can search for patterns in a syntax tree using a *tree query*:

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -362,6 +362,30 @@ class TestTree(TestCase):
             ),
         )
 
+    def test_get_changed_ranges(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        tree = parser.parse(b"def foo():\n  bar()")
+
+        edit_offset = len(b"def foo(")
+        tree.edit(
+            start_byte=edit_offset,
+            old_end_byte=edit_offset,
+            new_end_byte=edit_offset + 2,
+            start_point=(0, edit_offset),
+            old_end_point=(0, edit_offset),
+            new_end_point=(0, edit_offset + 2),
+        )
+
+        new_tree = parser.parse(b"def foo(ab):\n  bar()", tree)
+        changed_ranges = tree.get_changed_ranges(new_tree)
+
+        self.assertEqual(len(changed_ranges), 1)
+        self.assertEqual(changed_ranges[0].start_byte, edit_offset)
+        self.assertEqual(changed_ranges[0].start_point, (0, edit_offset))
+        self.assertEqual(changed_ranges[0].end_byte, edit_offset + 2)
+        self.assertEqual(changed_ranges[0].end_point, (0, edit_offset + 2))
+
 
 class TestQuery(TestCase):
     def test_errors(self):

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -35,6 +35,11 @@ typedef struct {
   PyObject *capture_names;
 } Query;
 
+typedef struct {
+  PyObject_HEAD
+  TSRange range;
+} Range;
+
 static TSTreeCursor default_cursor = {0};
 static TSQueryCursor *query_cursor = NULL;
 
@@ -329,6 +334,9 @@ static bool node_is_instance(PyObject *self) {
 
 // Tree
 
+static PyObject *range_new_internal(TSRange range);
+static PyTypeObject tree_type;
+
 static void tree_dealloc(Tree *self) {
   ts_tree_delete(self->tree);
   Py_TYPE(self)->tp_free((PyObject *)self);
@@ -387,6 +395,42 @@ static PyObject *tree_edit(Tree *self, PyObject *args, PyObject *kwargs) {
   Py_RETURN_NONE;
 }
 
+static PyObject *tree_get_changed_ranges(Tree *self, PyObject *args, PyObject *kwargs) {
+  char *keywords[] = {
+    "new_tree",
+    NULL,
+  };
+
+  Tree *new_tree = NULL;
+
+  int ok = PyArg_ParseTupleAndKeywords(
+    args,
+    kwargs,
+    "O",
+    keywords,
+    (PyObject **)&new_tree
+  );
+  if (!ok) return NULL;
+
+  if (!PyObject_IsInstance((PyObject *)new_tree, (PyObject *)&tree_type)) {
+    PyErr_SetString(PyExc_TypeError, "First argument to get_changed_ranges must be a Tree");
+    return NULL;
+  }
+
+  uint32_t length = 0;
+  TSRange *ranges = ts_tree_get_changed_ranges(self->tree, new_tree->tree, &length);
+
+  PyObject *result = PyList_New(length);
+  for(size_t i=0; i<(size_t)length; i++) {
+    PyObject *range = range_new_internal(ranges[i]);
+    PyList_SetItem(result, i, range);
+  }
+
+  free(ranges);
+
+  return result;
+}
+
 static PyMethodDef tree_methods[] = {
   {
     .ml_name = "walk",
@@ -402,6 +446,13 @@ static PyMethodDef tree_methods[] = {
     .ml_doc = "edit(start_byte, old_end_byte, new_end_byte,\
                start_point, old_end_point, new_end_point)\n--\n\n\
                Edit the syntax tree.",
+  },
+  {
+    .ml_name = "get_changed_ranges",
+    .ml_meth = (PyCFunction)tree_get_changed_ranges,
+    .ml_flags = METH_KEYWORDS|METH_VARARGS,
+    .ml_doc = "get_changed_ranges(new_tree)\n--\n\n\
+               Compare old edited tree to new tree and return changed ranges.",
   },
   {NULL},
 };
@@ -805,6 +856,94 @@ static PyObject *query_new_internal(
   return (PyObject *)query;
 }
 
+// Range
+
+static PyTypeObject range_type;
+
+static void range_dealloc(Range *self) {
+  Py_TYPE(self)->tp_free(self);
+}
+
+static PyObject *range_repr(Range *self) {
+  const char *format_string = "<Range start_point=(%u, %u), start_byte=%u, end_point=(%u, %u), end_byte=%u>";
+  return PyUnicode_FromFormat(
+    format_string,
+    self->range.start_point.row,
+    self->range.start_point.column,
+    self->range.start_byte,
+    self->range.end_point.row,
+    self->range.end_point.column,
+    self->range.end_byte
+ );
+}
+
+static bool range_is_instance(PyObject *self) {
+  return PyObject_IsInstance(self, (PyObject *)&range_type);
+}
+
+static PyObject *range_compare(Range *self, Range *other, int op) {
+  if (range_is_instance((PyObject *)other)) {
+    bool result = (
+      (self->range.start_point.row == other->range.start_point.row) &&
+      (self->range.start_point.column == other->range.start_point.column) &&
+      (self->range.start_byte == other->range.start_byte) &&
+      (self->range.end_point.row == other->range.end_point.row) &&
+      (self->range.end_point.column == other->range.end_point.column) &&
+      (self->range.end_byte == other->range.end_byte)
+    );
+    switch (op) {
+      case Py_EQ: return PyBool_FromLong(result);
+      case Py_NE: return PyBool_FromLong(!result);
+      default: Py_RETURN_FALSE;
+    }
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
+static PyObject *range_get_start_point(Range *self, void *payload) {
+  return point_new(self->range.start_point);
+}
+
+static PyObject *range_get_end_point(Range *self, void *payload) {
+  return point_new(self->range.end_point);
+}
+
+static PyObject *range_get_start_byte(Range *self, void *payload) {
+  return PyLong_FromSize_t((size_t)(self->range.start_byte));
+}
+
+static PyObject *range_get_end_byte(Range *self, void *payload) {
+  return PyLong_FromSize_t((size_t)(self->range.end_byte));
+}
+
+static PyGetSetDef range_accessors[] = {
+  {"start_point", (getter)range_get_start_point, NULL, "The start point of this range", NULL},
+  {"start_byte", (getter)range_get_start_byte, NULL, "The start byte of this range", NULL},
+  {"end_point", (getter)range_get_end_point, NULL, "The end point of this range", NULL},
+  {"end_byte", (getter)range_get_end_byte, NULL, "The end byte of this range", NULL},
+  {NULL}
+};
+
+static PyTypeObject range_type = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  .tp_name = "tree_sitter.Range",
+  .tp_doc = "A range within a document.",
+  .tp_basicsize = sizeof(Range),
+  .tp_itemsize = 0,
+  .tp_flags = Py_TPFLAGS_DEFAULT,
+  .tp_dealloc = (destructor)range_dealloc,
+  .tp_repr = (reprfunc)range_repr,
+  .tp_richcompare = (richcmpfunc)range_compare,
+  .tp_getset = range_accessors,
+};
+
+static PyObject *range_new_internal(TSRange range) {
+  Range *self = (Range *)range_type.tp_alloc(&range_type, 0);
+  if (self != NULL) self->range = range;
+  return (PyObject *)self;
+}
+
 // Module
 
 static PyObject *language_field_id_for_name(PyObject *self, PyObject *args) {
@@ -887,6 +1026,10 @@ PyMODINIT_FUNC PyInit_binding(void) {
   if (PyType_Ready(&query_type) < 0) return NULL;
   Py_INCREF(&query_type);
   PyModule_AddObject(module, "Query", (PyObject *)&query_type);
+
+  if (PyType_Ready(&range_type) < 0) return NULL;
+  Py_INCREF(&range_type);
+  PyModule_AddObject(module, "Range", (PyObject *)&range_type);
 
   return module;
 }


### PR DESCRIPTION
Expose the ts_tree_get_changed_ranges() functionality by exposing a
method for Tree called get_changed_ranges(). This should be called on
the *old* tree passing in the *new* one. (This mirrors the argument
ordering of ts_tree_get_changed_ranges().)

The return value is a list of Range objects which wrap the TSRange
structure and provide getters for the {start,end}_{point,byte} members.

A simple test is added as part of the Tree test suite and the README is
updated to document the new method.

Closes #28 