### PR TITLE
expose ts_query_cursor_set_{byte,point}_range

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,9 @@ assert len(captures) == 2
 assert captures[0][0] == function_name_node
 assert captures[0][1] == "function.def"
 ```
+
+The `Query.captures()` method takes optional `start_point`, `end_point`,
+`start_byte` and `end_byte` keyword arguments which can be used to restrict the
+query's range. Only one of the `..._byte` or `..._point` pairs need to be given
+to restrict the range. If all are omitted, the entire range of the passed node
+is used.

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -408,6 +408,48 @@ class TestQuery(TestCase):
         self.assertEqual(captures[3][0].end_point, (3, 6))
         self.assertEqual(captures[3][1], "func-call")
 
+    def test_byte_range_captures(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        source = b"def foo():\n  bar()\ndef baz():\n  quux()\n"
+        tree = parser.parse(source)
+        query = PYTHON.query(
+            """
+            (function_definition name: (identifier) @func-def)
+            (call function: (identifier) @func-call)
+            """
+        )
+
+        captures = query.captures(tree.root_node, start_byte=10, end_byte=20)
+        captures = query.captures(tree.root_node, start_byte=10, end_byte=20)
+        captures = query.captures(tree.root_node, start_byte=10, end_byte=20)
+        captures = query.captures(tree.root_node, start_byte=10, end_byte=20)
+
+        self.assertEqual(captures[0][0].start_point, (1, 2))
+        self.assertEqual(captures[0][0].end_point, (1, 5))
+        self.assertEqual(captures[0][1], "func-call")
+
+    def test_point_range_captures(self):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        source = b"def foo():\n  bar()\ndef baz():\n  quux()\n"
+        tree = parser.parse(source)
+        query = PYTHON.query(
+            """
+            (function_definition name: (identifier) @func-def)
+            (call function: (identifier) @func-call)
+            """
+        )
+
+        captures = query.captures(tree.root_node, start_point=(1, 0), end_point=(2, 0))
+        captures = query.captures(tree.root_node, start_point=(1, 0), end_point=(2, 0))
+        captures = query.captures(tree.root_node, start_point=(1, 0), end_point=(2, 0))
+        captures = query.captures(tree.root_node, start_point=(1, 0), end_point=(2, 0))
+
+        self.assertEqual(captures[0][0].start_point, (1, 2))
+        self.assertEqual(captures[0][0].end_point, (1, 5))
+        self.assertEqual(captures[0][1], "func-call")
+
 
 def trim(string):
     return re.sub(r"\s+", " ", string).strip()

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -675,22 +675,27 @@ static PyObject *query_captures(Query *self, PyObject *args, PyObject *kwargs) {
     "node",
     "start_point",
     "end_point",
+    "start_byte",
+    "end_byte",
     NULL,
   };
 
   Node *node = NULL;
-  unsigned start_row = 0, start_column = 0, end_row = 0, end_column = 0;
+  Py_ssize_t start_row = -1, start_column = -1, end_row = -1, end_column = -1;
+  Py_ssize_t start_byte = -1, end_byte = -1;
 
   int ok = PyArg_ParseTupleAndKeywords(
     args,
     kwargs,
-    "O|(II)(II)",
+    "O|(nn)(nn)nn",
     keywords,
     (PyObject **)&node,
     &start_row,
     &start_column,
     &end_row,
-    &end_column
+    &end_column,
+    &start_byte,
+    &end_byte
   );
   if (!ok) return NULL;
 
@@ -700,6 +705,28 @@ static PyObject *query_captures(Query *self, PyObject *args, PyObject *kwargs) {
   }
 
   if (!query_cursor) query_cursor = ts_query_cursor_new();
+
+  if((start_row < 0) && (end_row < 0) && (start_column < 0) && (end_column < 0) &&
+      (start_byte < 0) && (end_byte < 0)) {
+    // We default to the node start and end bytes if a specific value has not been
+    // passed to the function. We have to set this since we re-use the query
+    // cursor between calls.
+    ts_query_cursor_set_byte_range(
+      query_cursor, ts_node_start_byte(node->node), ts_node_end_byte(node->node)
+    );
+  } else if((start_row >= 0) && (end_row >= 0) && (start_column >= 0) && (end_column >= 0)) {
+    // Use the start and end points if specified
+    TSPoint start_point = { .row = start_row, .column = start_column };
+    TSPoint end_point = { .row = end_row, .column = end_column };
+    ts_query_cursor_set_point_range(query_cursor, start_point, end_point);
+  } else if((start_byte >= 0) && (end_byte >= 0)) {
+    // Use the start and end bytes if specified.
+    ts_query_cursor_set_byte_range(query_cursor, start_byte, end_byte);
+  } else {
+    PyErr_SetString(PyExc_TypeError, "Both start and end point must be specified if one is.");
+    return NULL;
+  }
+
   ts_query_cursor_exec(query_cursor, self->query, node->node);
 
   PyObject *result = PyList_New(0);


### PR DESCRIPTION
Some of the ground work for this had already been done; the
Query.captures() method already had {start,end}_point keyword arguments
but they were ignored.

Complete the keyword arguments by adding {start,end}_byte arguments.
Parse the arguments as Py_ssize_t-s as they need to be large enough to
represent memory offsets. Using a signed type allows the default values
to be -1, in which case the full node range is used which preserves the
original functionality.

Add tests of the byte and point range keywords and update README.