### PR TITLE
Use c++17 for non-c files

### DIFF
--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -61,6 +61,9 @@ class Language:
                     flags = ["-fPIC"]
                     if source_path.endswith(".c"):
                         flags.append("-std=c99")
+                    else:
+                        flags.append("-std=c++17")
+
                 object_paths.append(
                     compiler.compile(
                         [source_path],


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter-haskell uses `c++17` language features, so needs to be built with that flag. 

Test output:
```
...........
----------------------------------------------------------------------
Ran 11 tests in 0.012s

OK
```