### PR TITLE
Fix Linux build with libcxx present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        python:
+          - "3.5"
+          - "3.8"
+          - pypy-3.7
+        install_libcxx:
+          - false
+          - true
+        exclude:
+          - os: windows-latest
+            install_libcxx: true
+          - os: macos-latest
+            install_libcxx: true
+          - os: macos-latest
+            python: pypy-3.7
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Uninstall libcxx
+        if: ${{ matrix.os == 'ubuntu-latest' && !matrix.install_libcxx }}
+        run: |
+          DEBIAN_FRONTEND=noninteractive sudo apt-get purge -y 'libc++*'
+      - name: Install libcxx
+        if: ${{ matrix.install_libcxx }}
+        run: |
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libc++-dev libc++abi-dev
+      - name: Install flake8
+        run: python -m pip install flake8
+      - name: Fetch fixtures
+        run: ./script/fetch-fixtures
+      - name: Lint
+        run: ./script/lint
+      - name: Test
+        shell: bash
+        run: |
+          CFLAGS="-O0 -g" python setup.py test

--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -1,8 +1,8 @@
 """Python bindings for tree-sitter."""
 
 from ctypes import cdll, c_void_p
-from ctypes.util import find_library
 from distutils.ccompiler import new_compiler
+from distutils.unixccompiler import UnixCCompiler
 from os import path
 from platform import system
 from tempfile import TemporaryDirectory
@@ -43,11 +43,8 @@ class Language:
         ]
 
         compiler = new_compiler()
-        if cpp:
-            if find_library("c++"):
-                compiler.add_library("c++")
-            elif find_library("stdc++"):
-                compiler.add_library("stdc++")
+        if isinstance(compiler, UnixCCompiler):
+            compiler.compiler_cxx[0] = "c++"
 
         if max(source_mtimes) <= output_mtime:
             return False
@@ -69,7 +66,11 @@ class Language:
                         extra_preargs=flags,
                     )[0]
                 )
-            compiler.link_shared_object(object_paths, output_path)
+            compiler.link_shared_object(
+                object_paths,
+                output_path,
+                target_lang="c++" if cpp else "c",
+            )
         return True
 
     def __init__(self, library_path, name):


### PR DESCRIPTION
When a tree sitter grammar contains a `scanner.cc` file, a C++ standard
library must be linked to the final grammar shared object. `distutils`
uses the default `cc` compiler driver to compile and link C and C++
files. On Linux, this is GCC, so `libstdc++` must be linked, even if
`libc++` is present.

On Mac, `libc++` is the default, even if `libstdc++` is present.

Use the `c++` compiler driver for linking, so that the appropriate standard library
is selected automatically.

----

This PR also adds CI for Mac (as well as Ubuntu and Windows) using GitHub actions.

Resolves #43, resolves #41, resolves #27.