### PR TITLE
Add text property to tree and node objects

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -283,6 +283,16 @@ class TestNode(TestCase):
         root_node_again = tree.root_node
         self.assertEqual(root_node_again.text, None)
 
+        tree_text_false = parser.parse(b"[0, [1, 2, 3]]", keep_text=False)
+        self.assertIsNone(tree_text_false.text)
+        root_node_text_false = tree_text_false.root_node
+        self.assertIsNone(root_node_text_false.text)
+
+        tree_text_true = parser.parse(b"[0, [1, 2, 3]]", keep_text=True)
+        self.assertEqual(tree_text_true.text, b"[0, [1, 2, 3]]")
+        root_node_text_true = tree_text_true.root_node
+        self.assertEqual(root_node_text_true.text, b"[0, [1, 2, 3]]")
+
     def test_tree(self):
         code = b"def foo():\n  bar()\n\ndef foo():\n  bar()"
         parser = Parser()

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -300,7 +300,6 @@ static PyObject *node_get_text(Node *self, void *payload) {
                     "PyObject_GetItem failed");
     return NULL;
   }
-  Py_INCREF(node_slice);
   return PyBytes_FromObject(node_slice);
 }
 

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -260,7 +260,7 @@ static PyObject *node_get_text(Node *self, void *payload) {
   if (source == Py_None) {
     Py_RETURN_NONE;
   }
-  // "hello"[1:3] == "hello".__getitem__(slice(1, 3))
+
   PyObject *start_byte =
     PyLong_FromSize_t((size_t)ts_node_start_byte(self->node));
   if (start_byte == NULL) {
@@ -301,7 +301,7 @@ static PyObject *node_get_text(Node *self, void *payload) {
     return NULL;
   }
   Py_INCREF(node_slice);
-  return node_slice;
+  return PyBytes_FromObject(node_slice);
 }
 
 static PyMethodDef node_methods[] = {


### PR DESCRIPTION
This PR attempts to finish the work started by @sogaiu in PR #37 to address issue #36. 

A summary of the features implemented in this PR:
- `.text` preoperty can be accessed on tree and node objects, which will return the source code of the object as bytes
- `.text` returns `None` if the tree has been edited (present in the original PR)
- `.text` accesses the source code using MemoryViews to avoid copying the data when slicing (present in the original PR, though a tweak has been added to obtain the desired behavior)
- `parser_parse()` has now an optional (keyword) parameter `keep_text` (as suggested in https://github.com/tree-sitter/py-tree-sitter/pull/37#issuecomment-703305527). When setting it to `False`, no source code will be stored in the tree object and `.text` will return `None`. Default value is `True`
- Some tests for the `.text`functionality (a few have been added to the ones in the original PR to validate the behavior for the `keep_text` parameter) 