### PR TITLE
Query predicates

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -468,11 +468,11 @@ class TestQuery(TestCase):
                 key1: value1,
                 equal: equal
             }
-            
+
             function fun1(arg) {
                 return 1;
             }
-            
+
             function fun2(arg) {
                 return 2;
             }
@@ -522,7 +522,8 @@ class TestQuery(TestCase):
         self.assertSetEqual({b"equal"}, set([c[0].text for c in captures3]))
         self.assertSetEqual({"key-name", "value-name"}, set([c[1] for c in captures3]))
 
-        # key pairs whose key is not equal to its value -> test for #not-eq? @capture1 @capture2
+        # key pairs whose key is not equal to its value
+        # -> test for #not-eq? @capture1 @capture2
         query4 = JAVASCRIPT.query("""
                     (
                       (pair

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -1138,6 +1138,7 @@ static PyObject *query_new_internal(
         int is_positive = PyUnicode_CompareWithASCIIString(operator_name, "eq?") == 0;
         switch ((predicate_step + 2)->type) {
           case TSQueryPredicateStepTypeCapture:
+            ;
             CaptureEqCapture *capture_eq_capture_predicate = (CaptureEqCapture *)capture_eq_capture_new_internal(
               (predicate_step+1)->value_id, (predicate_step+2)->value_id, is_positive
             );
@@ -1149,6 +1150,7 @@ static PyObject *query_new_internal(
             Py_DECREF(capture_eq_capture_predicate);
             break;
           case TSQueryPredicateStepTypeString:
+            ;
             Py_ssize_t size;
             const char *string_value = PyUnicode_AsUTF8AndSize(
               PyList_GetItem(query->string_values, (predicate_step+2)->value_id), &size

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -65,7 +65,7 @@ typedef struct {
 
 static TSTreeCursor default_cursor = {0};
 static TSQueryCursor *query_cursor = NULL;
-static PyObject *re_module = NULL;
+static PyObject *re_compile = NULL;
 
 // Point
 
@@ -858,15 +858,11 @@ static PyObject *capture_eq_string_new_internal(uint32_t capture_value_id, const
 }
 
 static PyObject *capture_match_string_new_internal(uint32_t capture_value_id, const char *string_value, int is_positive) {
-  if (re_module == NULL)
-    re_module = PyImport_ImportModule("re");
   CaptureMatchString *self = (CaptureMatchString *)capture_match_string_type.tp_alloc(&capture_match_string_type, 0);
-  if (re_module == NULL || self == NULL)
+  if (self == NULL)
     return NULL;
   self->capture_value_id = capture_value_id;
-  PyObject *re_compile = PyObject_GetAttrString(re_module,(char*)"compile");
   self->regex = PyObject_CallFunction(re_compile, "s", string_value);
-  Py_DECREF(re_compile);
   self->is_positive = is_positive;
   return (PyObject *)self;
 }
@@ -1324,6 +1320,12 @@ PyMODINIT_FUNC PyInit_binding(void) {
   if (PyType_Ready(&query_type) < 0) return NULL;
   Py_INCREF(&query_type);
   PyModule_AddObject(module, "Query", (PyObject *)&query_type);
+
+  PyObject *re_module = PyImport_ImportModule("re");
+  if (re_module == NULL) return NULL;
+  re_compile = PyObject_GetAttrString(re_module,(char*)"compile");
+  Py_DECREF(re_module);
+  if (re_compile == NULL) return NULL;
 
   return module;
 }

--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -31,21 +31,21 @@ typedef struct {
 } TreeCursor;
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   uint32_t capture1_value_id;
   uint32_t capture2_value_id;
   int is_positive;
 } CaptureEqCapture;
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   uint32_t capture_value_id;
   PyObject *string_value;
   int is_positive;
 } CaptureEqString;
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   uint32_t capture_value_id;
   PyObject *regex;
   int is_positive;


### PR DESCRIPTION
This PR adds support for predicates in queries, which resolves #22. I have tried to replicate the same overall steps performed by the Rust bindings (whenever possible), as it seemed reasonable and that it would help keep some coherence between the bindings.

Here is summary of the changes implemented in this PR:
- If a text predicate is present in a query, results are filtered according to it. The supported operators are #eq?, #not-eq?, #match? and #not-match? (other operators are ignored and will not affect the result of the query)
- Basic tests for these operators have been added
- The Query object has two new attributes: `string_values` (a list of all the parsed strings of the query) and `text_predicates` (a list of all text predicates of the query)
- New PyObject types have been defined, namely:
   - `QueryCapture`, which represents an individual capture of the query
   - `CaptureEqCapture`, which represents a text predicate of the form `#eq? @capture1 @capture2` or `#not-eq? @capture1 @capture2`
   - `CaptureEqString`, which represents a text predicate of the form `#eq? @capture string` or `#not-eq? @capture string`
   - `CaptureMatchString`, which represents a text predicate of the form `#match? @capture regex` or `#not-match? @capture regex`

The Python method `Query.captures` (implemented in the C function `query_captures`) still returns a tuple `(node, capture_name)`. My opinion is that it would be more coherent to return `QueryCapture` objects now that are defined, but since this would be a breaking change I decided to leave it out of this PR for now. However, I can add it if you think it's appropriate.