### PR TITLE
Add visitors to the Tree-sitter Python API

### DIFF
--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -8,6 +8,7 @@ from platform import system
 from tempfile import TemporaryDirectory
 from tree_sitter.binding import _language_field_id_for_name, _language_query
 from tree_sitter.binding import Node, Parser, Tree, TreeCursor  # noqa: F401
+from tree_sitter.visitor import ASTVisitor
 
 
 class Language:

--- a/tree_sitter/visitor.py
+++ b/tree_sitter/visitor.py
@@ -1,0 +1,101 @@
+
+
+class ASTVisitor:
+    """
+    Visitor to traverse a given abstract syntax tree
+
+    The class implements the visitor design pattern
+    to visit nodes inside an abstract syntax tree.
+    The syntax tree is traversed in pre-order by employing
+    a tree cursor. 
+
+    Custom visitors should subclass the ASTVisitor:
+
+    ```
+    class AllNodesVisitor(tree_sitter.ASTVisitor):
+
+        def visit_module(self, module_node):
+            # Called for nodes of type module only
+            ...
+        
+        def visit(self, node):
+            # Called for all nodes where a specific handler does not exist
+            # e.g. here called for all nodes that are not modules
+            ...
+
+        def visit_string(self, node):
+            # Stops traversing subtrees rooted at a string
+            # Traversal can be stopped by returning False
+            return False
+
+    ```
+    
+    """
+
+    def visit(self, node):
+        """Default handler that captures all nodes not already handled"""
+
+    def visit_ERROR(self, error_node):
+        """
+        Handler for errors marked in AST.
+
+        The subtree below an ERROR node can sometimes form unexpected AST structures.
+        The default strategy is therefore to skip all subtrees rooted at an ERROR node.
+        Override for a custom error handler.
+        """
+        return False
+
+    # Traversing ----------------------------------------------------------------
+
+    def on_visit(self, node):
+        """
+        Handles all nodes visted in AST and calls the underlying vistor methods.
+
+        This method is called for all discovered AST nodes first.
+        Override this to handle all nodes regardless of the defined visitor methods.
+
+        Returning False stops the traversal of the subtree rooted at the given node.
+        """
+        visitor_fn = getattr(self, "visit_%s" % node.type, self.visit)
+        return visitor_fn(node) is not False
+
+    def walk(self, tree):
+        """
+        Walks a given (sub)tree by using the cursor API
+
+        This method walks every node in a given subtree in pre-order traversal.
+        During the traversal, the respective visitor method is called.
+        """
+        
+        cursor   = tree.walk()
+        has_next = True
+
+        while has_next:
+            current_node = cursor.node
+
+            if self.on_visit(current_node):
+                has_next = cursor.goto_first_child()
+            else:
+                has_next = False
+
+            if not has_next: has_next = cursor.goto_next_sibling()
+
+            previous_node = current_node
+
+            while not has_next and cursor.goto_parent():
+                has_next = cursor.goto_next_sibling()
+
+                # Nodes marked as missing sometimes create loops in AST
+                has_next = has_next and not _node_equal(previous_node, cursor.node)
+
+
+# Helper --------------------------------
+
+def _node_equal(n1, n2):
+    if n1 == n2: return True
+    try:
+        return (n1.type == n2.type 
+                    and n1.start_point == n2.start_point
+                    and n1.end_point   == n2.end_point)
+    except AttributeError:
+        return n1 == n2

--- a/tree_sitter/visitor.py
+++ b/tree_sitter/visitor.py
@@ -1,4 +1,4 @@
-"""This module implements the visitor design pattern for TreeSitter"""
+"""This module implements the visitor design pattern for Tree-sitter"""
 
 class ASTVisitor:
     """
@@ -80,24 +80,5 @@ class ASTVisitor:
             if not has_next:
                 has_next = cursor.goto_next_sibling()
 
-            previous_node = current_node
-
             while not has_next and cursor.goto_parent():
                 has_next = cursor.goto_next_sibling()
-
-                # Nodes marked as missing sometimes create loops in AST
-                has_next = has_next and not _node_equal(previous_node, cursor.node)
-
-
-# Helper --------------------------------
-
-def _node_equal(node, node_other):
-    if node == node_other:
-        return True
-
-    try:
-        return (node.type == node_other.type
-                    and node.start_point == node_other.start_point
-                    and node.end_point   == node_other.end_point)
-    except AttributeError:
-        return node == node_other

--- a/tree_sitter/visitor.py
+++ b/tree_sitter/visitor.py
@@ -1,4 +1,4 @@
-
+"""This module implements the visitor design pattern for TreeSitter"""
 
 class ASTVisitor:
     """
@@ -7,7 +7,7 @@ class ASTVisitor:
     The class implements the visitor design pattern
     to visit nodes inside an abstract syntax tree.
     The syntax tree is traversed in pre-order by employing
-    a tree cursor. 
+    a tree cursor.
 
     Custom visitors should subclass the ASTVisitor:
 
@@ -17,7 +17,7 @@ class ASTVisitor:
         def visit_module(self, module_node):
             # Called for nodes of type module only
             ...
-        
+
         def visit(self, node):
             # Called for all nodes where a specific handler does not exist
             # e.g. here called for all nodes that are not modules
@@ -29,7 +29,6 @@ class ASTVisitor:
             return False
 
     ```
-    
     """
 
     def visit(self, node):
@@ -56,7 +55,7 @@ class ASTVisitor:
 
         Returning False stops the traversal of the subtree rooted at the given node.
         """
-        visitor_fn = getattr(self, "visit_%s" % node.type, self.visit)
+        visitor_fn = getattr(self, f"visit_{node.type}", self.visit)
         return visitor_fn(node) is not False
 
     def walk(self, tree):
@@ -66,7 +65,7 @@ class ASTVisitor:
         This method walks every node in a given subtree in pre-order traversal.
         During the traversal, the respective visitor method is called.
         """
-        
+
         cursor   = tree.walk()
         has_next = True
 
@@ -78,7 +77,8 @@ class ASTVisitor:
             else:
                 has_next = False
 
-            if not has_next: has_next = cursor.goto_next_sibling()
+            if not has_next:
+                has_next = cursor.goto_next_sibling()
 
             previous_node = current_node
 
@@ -91,11 +91,13 @@ class ASTVisitor:
 
 # Helper --------------------------------
 
-def _node_equal(n1, n2):
-    if n1 == n2: return True
+def _node_equal(node, node_other):
+    if node == node_other:
+        return True
+
     try:
-        return (n1.type == n2.type 
-                    and n1.start_point == n2.start_point
-                    and n1.end_point   == n2.end_point)
+        return (node.type == node_other.type
+                    and node.start_point == node_other.start_point
+                    and node.end_point   == node_other.end_point)
     except AttributeError:
-        return n1 == n2
+        return node == node_other


### PR DESCRIPTION
## Feature request: visitor pattern

This PR represents a feature request for the visitor pattern to be included in the Tree-sitter Python API.
The visitor pattern is well-established method for processing large hierarchical object structures including
abstract syntax trees.

While this use case is essentially covered by `TreeCursor`, visitors can provide an convenient method for traversing
the whole tree structure. In addition, this PR would provide a native interface for resolving issues like #32 and #33.

Here is a summary of the changes implemented by this PR:
* Add new module `visitor` which includes the implementation of `ASTVisitor`
* `ASTVisitor` implement the visitor pattern based on the `TreeCursor` API
* The visitor conveniently traverses the tree in pre-order traversal. The implementation has minimal overhead and is inline with previous implementation (e.g. the one found in [this comment](https://github.com/tree-sitter/py-tree-sitter/issues/33#issuecomment-864557166)).
* New visitor implementation can subclass `ASTVisitor`. Nodes are handled by defining new methods `visit_[Node type]` where Node type is the type of the node that should be handled.

This implementation has be proven to be really valuable in our recent research projects. Therefore, I like to contribute this
to the official Tree-sitter Python API. In addition, I think that visitors could be valuable alternative for interfacing the parsed AST trees (especially when the complete tree has to be traversed). 

