### PR TITLE
Use consistent attribute names in repr

### DIFF
--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -105,8 +105,8 @@ static PyObject *node_repr(Node *self) {
   TSPoint start_point = ts_node_start_point(self->node);
   TSPoint end_point = ts_node_end_point(self->node);
   const char *format_string = ts_node_is_named(self->node)
-    ? "<Node kind=%s, start_point=(%u, %u), end_point=(%u, %u)>"
-    : "<Node kind=\"%s\", start_point=(%u, %u), end_point=(%u, %u)>";
+    ? "<Node type=%s, start_point=(%u, %u), end_point=(%u, %u)>"
+    : "<Node type=\"%s\", start_point=(%u, %u), end_point=(%u, %u)>";
   return PyUnicode_FromFormat(
     format_string,
     type,


### PR DESCRIPTION
I noticed this small inconsistency while using tree_sitter. bug or feature?

```
<Node kind=expression_statement, start_point=(0, 0), end_point=(0, 38)>
ipdb> node.type
'expression_statement'
ipdb> node.kind
*** AttributeError: 'tree_sitter.Node' object has no attribute 'kind'
```