### PR TITLE
add test that returned a result with an exception set

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -886,6 +886,22 @@ class TestQuery(TestCase):
         self.assertEqual(captures[1][0].end_point, (1, 5))
         self.assertEqual(captures[1][1], "func-call")
 
+    def test_match_assert(self,):
+        parser = Parser()
+        parser.set_language(PYTHON)
+        source = b"""def f():
+    self.assertTrue(True)
+    assert True"""
+        tree = parser.parse(source)
+        query = PYTHON.query(
+            """
+            ([(call function: (attribute (identifier) @assert_true (#match? @assert_true "^assertTrue$"))) ((assert_statement) @assert)])
+            """
+        )
+
+        captures = query.captures(tree.root_node)
+        self.assertEqual(len(captures), 2)
+
 
 def trim(string):
     return re.sub(r"\s+", " ", string).strip()


### PR DESCRIPTION
The test included here returns:

```bash
======================================================================
ERROR: test_match_assert (tests.test_tree_sitter.TestQuery)
----------------------------------------------------------------------
ValueError: An error occurred, capture was not found with given index

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/py-tree-sitter/tests/test_tree_sitter.py", line 902, in test_match_assert
    captures = query.captures(tree.root_node)
SystemError: <method 'captures' of 'tree_sitter.Query' objects> returned a result with an exception set

----------------------------------------------------------------------
```

however, works as expected on the [playground](https://tree-sitter.github.io/tree-sitter/playground) 