### PR TITLE
Make match captures a dict[str,Node|list[Node]]

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -1269,12 +1269,13 @@ class TestQuery(TestCase):
         captures: Dict[str, Union[Node, List[Node]]],
     ) -> List[Tuple[str, str]]:
         return [(name, self.format_capture(capture)) for name, capture in captures.items()]
-    
-    def format_capture(
-            self,
-            capture: Union[Node, List[Node]]
-    ) -> str:
-        return '[' + ", ".join(["'" + n.text.decode("utf-8") + "'" for n in capture]) + ']' if isinstance(capture, List) else capture.text.decode("utf-8")
+
+    def format_capture(self, capture: Union[Node, List[Node]]) -> str:
+        return (
+            "[" + ", ".join(["'" + n.text.decode("utf-8") + "'" for n in capture]) + "]"
+            if isinstance(capture, List)
+            else capture.text.decode("utf-8")
+        )
 
     def assert_query_matches(
         self,
@@ -1374,23 +1375,33 @@ class TestQuery(TestCase):
         )
 
     def test_matches_with_list_capture(self):
-        query = JAVASCRIPT.query("(function_declaration name: (identifier) @fn-name body: (statement_block (_)* @fn-statements))")
+        query = JAVASCRIPT.query(
+            """(function_declaration name: (identifier) @fn-name
+                                     body: (statement_block (_)* @fn-statements)
+                )"""
+        )
         self.assert_query_matches(
             JAVASCRIPT,
             query,
-            b"""function one() { 
+            b"""function one() {
                     x = 1;
                     y = 2;
-                    z = 3; 
-                } 
-                function two() { 
+                    z = 3;
+                }
+                function two() {
                     x = 1;
                 }
             """,
             [
-                (0, [('fn-name', 'one'), ('fn-statements', "['x = 1;', 'y = 2;', 'z = 3;']")]),
-                (0, [('fn-name', 'two'), ('fn-statements', "['x = 1;']")])
-            ]
+                (
+                    0,
+                    [
+                        ("fn-name", "one"),
+                        ("fn-statements", "['x = 1;', 'y = 2;', 'z = 3;']"),
+                    ],
+                ),
+                (0, [("fn-name", "two"), ("fn-statements", "['x = 1;']")]),
+            ],
         )
 
     def test_captures(self):

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -1,6 +1,6 @@
 import re
 from os import path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 from unittest import TestCase
 
 from tree_sitter import Language, LookaheadIterator, Node, Parser, Query, Range, Tree
@@ -1260,19 +1260,19 @@ class TestQuery(TestCase):
 
     def collect_matches(
         self,
-        matches: List[Tuple[int, Dict[str, Node|List[Node]]]],
+        matches: List[Tuple[int, Dict[str, Union[Node, List[Node]]]]],
     ) -> List[Tuple[int, List[Tuple[str, str]]]]:
         return [(m[0], self.format_captures(m[1])) for m in matches]
 
     def format_captures(
         self,
-        captures: Dict[str, Node|List[Node]],
+        captures: Dict[str, Union[Node, List[Node]]],
     ) -> List[Tuple[str, str]]:
         return [(name, self.format_capture(capture)) for name, capture in captures.items()]
     
     def format_capture(
             self,
-            capture: Node|List[Node]
+            capture: Union[Node, List[Node]]
     ) -> str:
         return '[' + ", ".join(["'" + n.text.decode("utf-8") + "'" for n in capture]) + ']' if isinstance(capture, List) else capture.text.decode("utf-8")
 

--- a/tree_sitter/_binding.pyi
+++ b/tree_sitter/_binding.pyi
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import tree_sitter
 
@@ -349,7 +349,7 @@ class Query:
         end_point: Optional[Tuple[int, int]] = None,
         start_byte: Optional[int] = None,
         end_byte: Optional[int] = None,
-    ) -> List[Tuple[int, Dict[str, Node | List[Node]]]]:
+    ) -> List[Tuple[int, Dict[str, Union[Node, List[Node]]]]]:
         """Get a list of all of the matches within the given node."""
 
     def captures(

--- a/tree_sitter/_binding.pyi
+++ b/tree_sitter/_binding.pyi
@@ -349,7 +349,7 @@ class Query:
         end_point: Optional[Tuple[int, int]] = None,
         start_byte: Optional[int] = None,
         end_byte: Optional[int] = None,
-    ) -> List[Tuple[int, List[Tuple[Node, str]]]]:
+    ) -> List[Tuple[int, Dict[str, Node | List[Node]]]]:
         """Get a list of all of the matches within the given node."""
 
     def captures(


### PR DESCRIPTION
Return the captures of a match as a dict where the key is the capture name and the value is a Node or a list of Nodes. For regular captures, the value is a Node. For captures that can contain multiple nodes because they use a * or + quantifier, the value is a list of Nodes.

---

Closes #182