### PR TITLE
Move `distutils` import into `Language.build_library`

### DIFF
--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -2,8 +2,6 @@
 
 import enum
 from ctypes import c_void_p, cdll
-from distutils.ccompiler import new_compiler
-from distutils.unixccompiler import UnixCCompiler
 from os import path
 from platform import system
 from tempfile import TemporaryDirectory
@@ -65,12 +63,17 @@ class Language:
             path.getmtime(path_) for path_ in source_paths
         ]
 
+        if max(source_mtimes) <= output_mtime:
+            return False
+
+        # local import saves import time in the common case that nothing is
+        # compiled
+        from distutils.ccompiler import new_compiler
+        from distutils.unixccompiler import UnixCCompiler
+
         compiler = new_compiler()
         if isinstance(compiler, UnixCCompiler):
             compiler.set_executables(compiler_cxx="c++")
-
-        if max(source_mtimes) <= output_mtime:
-            return False
 
         with TemporaryDirectory(suffix="tree_sitter_language") as out_dir:
             object_paths = []


### PR DESCRIPTION
Importing `distutils` takes more than 90% of the total import time of `tree_sitter`, but it is only used when compiling new languages. The common case should not need to pay for that.

Some measurements:

Without this PR:
```console
$ python -Ximporttime -c 'import tree_sitter'
import time: self [us] | cumulative | imported package
[...]
import time:       613 |        613 |         json.encoder
import time:       347 |       2441 |       json
import time:      2406 |     129771 |     distutils
import time:       513 |     130284 |   distutils.ccompiler
import time:       444 |        444 |     shlex
import time:       176 |        176 |       distutils.py39compat
import time:       168 |        168 |       distutils._functools
import time:       927 |       1269 |     distutils.sysconfig
import time:       168 |        168 |     distutils._macos_compat
import time:       361 |       2240 |   distutils.unixccompiler
import time:       653 |        653 |   tree_sitter.binding
import time:       871 |     140812 | tree_sitter
```

With this PR:
```console
$ python -Ximporttime -c "import tree_sitter" |& tail
import time:       214 |        214 |       _sha512
import time:       507 |       1625 |     random
import time:       309 |        309 |       _weakrefset
import time:       638 |        947 |     weakref
import time:       610 |       6328 |   tempfile
import time:       270 |        270 |     collections.abc
import time:       197 |        197 |     _typing
import time:      3145 |       3611 |   typing
import time:       404 |        404 |   tree_sitter.binding
import time:       702 |      16481 | tree_sitter
```