### PR TITLE
Fix type of Tree.text property

### DIFF
--- a/tree_sitter/binding.pyi
+++ b/tree_sitter/binding.pyi
@@ -216,7 +216,7 @@ class Tree:
         """The root node of this tree."""
         ...
     @property
-    def text(self) -> str:
+    def text(self) -> bytes:
         """The source text for this tree, if unedited."""
         ...
 


### PR DESCRIPTION
The .pyi file for the bindings report that Tree.text is a str but it is bytes. This was [fixed](https://github.com/tree-sitter/py-tree-sitter/commit/f246d063f8699ebce3aab9cf957447cb8db098e4) for Node.text but not for for Tree.