### PR TITLE
fix:#204

### DIFF
--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -119,6 +119,23 @@ class TestParser(TestCase):
             "'🐍'",
         )
 
+    def test_multibyte_characters_utf16(self):
+        parser = Parser()
+        parser.set_language(JAVASCRIPT)
+        source_code = bytes("'😎' && '🐍'", "utf16")
+        tree = parser.parse(source_code, encoding="utf16")
+        root_node = tree.root_node
+        statement_node = root_node.children[0]
+        binary_node = statement_node.children[0]
+        snake_node = binary_node.children[2]
+
+        self.assertEqual(binary_node.type, "binary_expression")
+        self.assertEqual(snake_node.type, "string")
+        self.assertEqual(
+            source_code[snake_node.start_byte : snake_node.end_byte].decode("utf16"),
+            "'🐍'",
+        )
+
     def test_buffer_protocol(self):
         parser = Parser()
         parser.set_language(JAVASCRIPT)
@@ -144,6 +161,28 @@ class TestParser(TestCase):
         self.assertEqual(snake_node.type, "string")
         self.assertEqual(
             source_code[snake_node.start_byte : snake_node.end_byte].decode("utf8"),
+            "'🐍'",
+        )
+
+    def test_multibyte_characters_utf16_via_read_callback(self):
+        parser = Parser()
+        parser.set_language(JAVASCRIPT)
+        source_code = bytes("'😎' && '🐍'", "utf16")
+
+        def read(byte_position, _):
+            # In utf16 encoding, word (2 bytes) should be the smallest unit.
+            return source_code[byte_position: byte_position + 2]
+
+        tree = parser.parse(read, encoding='utf16')
+        root_node = tree.root_node
+        statement_node = root_node.children[0]
+        binary_node = statement_node.children[0]
+        snake_node = binary_node.children[2]
+
+        self.assertEqual(binary_node.type, "binary_expression")
+        self.assertEqual(snake_node.type, "string")
+        self.assertEqual(
+            source_code[snake_node.start_byte: snake_node.end_byte].decode("utf16"),
             "'🐍'",
         )
 

--- a/tree_sitter/_binding.pyi
+++ b/tree_sitter/_binding.pyi
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, Literal
 
 import tree_sitter
 
@@ -318,6 +318,7 @@ class Parser:
         source_code: bytes | Callable[[int, Tuple[int, int]], Optional[bytes]],
         old_tree: Optional[Tree] = None,
         keep_text: Optional[bool] = True,
+        encoding: Literal['utf8', 'utf16'] = 'utf8'
     ) -> Tree:
         """Parse source code, creating a syntax tree.
         Note that by default `keep_text` will be True, unless source_code is a callable.


### PR DESCRIPTION
Hi, I have #204 finished and it passes all the tests I found under tests folder. 

The only API I changed is the "parser_parse" method which now takes the additional parameter "encoding" and uses "utf8" as the default value, but can also pass "utf16" to support UTF-16 encoded source code. It follows the encoding name convention (utf8/utf16 instead of utf-8/utf-16) I have found in this repo.

The new "parser_parse" method compatible with old method and does not interfere with existing libraries. 

And I have added two additional tests 
1. test_multibyte_characters_utf16 
2. test_multibyte_characters_utf16_via_read_callback
 
and updated README file for usage example.

I noticed that the existing tests are not enough but I am not going to add more unit tests, please understand : ), the only thing I can guarantee is that I am using it fine in my project and no problems have appeared so far ..