### PR TITLE
fix: prevent segmentation fault

### DIFF
--- a/tree_sitter/binding.c
+++ b/tree_sitter/binding.c
@@ -875,6 +875,9 @@ static PyType_Spec node_type_spec = {
 
 static PyObject *node_new_internal(ModuleState *state, TSNode node, PyObject *tree) {
     Node *self = (Node *)state->node_type->tp_alloc(state->node_type, 0);
+    if (ts_node_is_null(node)) {
+        Py_RETURN_NONE;
+    }
     if (self != NULL) {
         self->node = node;
         Py_INCREF(tree);


### PR DESCRIPTION
Fix the segmentation fault that occurs with the following code:

```python
PY_LANGUAGE = Language(tspython.language(), "python") # type: ignore
parser = Parser()
parser.set_language(PY_LANGUAGE)

tree = parser.parse(b"i = 0")
node = tree.root_node
v = node.child(node.child_count)

print(v)  # This line will cause a SIGSEGV

assert v is None
```

This commit corresponds to [this code](https://github.com/tree-sitter/tree-sitter/blob/b7fcf9878e1144a30e71ae94f951f163258770d9/lib/binding_rust/lib.rs#L976) in the Rust binding
