### PR TITLE
feat(parser): support UTF-16 encoding

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -131,6 +131,28 @@ class TestParser(TestCase):
             + " arguments: (argument_list))))))",
         )
 
+    def test_parse_utf16_encoding(self):
+        source_code = bytes("'😎' && '🐍'", "utf16")
+        parser = Parser(self.javascript)
+
+        def read(byte_position, _):
+            return source_code[byte_position: byte_position + 2]
+
+        tree = parser.parse(read, encoding="utf-16")
+        root_node = tree.root_node
+        snake_node = root_node.children[0].children[0].children[2]
+        snake = source_code[snake_node.start_byte + 2:snake_node.end_byte - 2]
+
+        self.assertEqual(snake_node.type, "string")
+        self.assertEqual(snake.decode("utf16"), "🐍")
+
+
+    def test_parse_invalid_encoding(self):
+        parser = Parser(self.python)
+        with self.assertRaises(ValueError):
+            parser.parse(b"foo", encoding="ascii")
+
+
     def test_parse_with_one_included_range(self):
         source_code = b"<span>hi</span><script>console.log('sup');</script>"
         parser = Parser(self.html)

--- a/tree_sitter/__init__.pyi
+++ b/tree_sitter/__init__.pyi
@@ -1,10 +1,12 @@
 from collections.abc import ByteString, Callable, Iterator, Sequence
-from typing import Annotated, Any, Final, NamedTuple, final, overload
+from typing import Annotated, Any, Final, Literal, NamedTuple, final, overload
 from typing_extensions import deprecated
 
 _Ptr = Annotated[int, "TSLanguage *"]
 
 _ParseCB = Callable[[int, Point | tuple[int, int]], bytes]
+
+_Encoding = Literal["utf8", "utf16"]
 
 _UINT32_MAX = 0xFFFFFFFF
 
@@ -247,6 +249,7 @@ class Parser:
         source: ByteString | _ParseCB | None,
         /,
         old_tree: Tree | None = None,
+        encoding: _Encoding = "utf8",
     ) -> Tree: ...
     @overload
     @deprecated("`keep_text` will be removed")
@@ -255,6 +258,7 @@ class Parser:
         source: ByteString | _ParseCB | None,
         /,
         old_tree: Tree | None = None,
+        encoding: _Encoding = "utf8",
         keep_text: bool = True,
     ) -> Tree: ...
     def reset(self) -> None: ...


### PR DESCRIPTION
`utf8` / `utf16` are preferred by any valid alias is supported.

Closes #204 & closes #211