### PR TITLE
binding/query.c: use PyErr_Format instead of _PyErr_FormatFromCause 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13-dev"]
         os: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{matrix.os}}
     steps:

--- a/tree_sitter/binding/query.c
+++ b/tree_sitter/binding/query.c
@@ -274,7 +274,7 @@ PyObject *query_new(PyTypeObject *cls, PyObject *args, PyObject *Py_UNUSED(kwarg
                 PyObject *pattern =
                     PyObject_CallFunction(state->re_compile, "s#", second_arg, length);
                 if (pattern == NULL) {
-                    _PyErr_FormatFromCause(
+                    PyErr_Format(
                         state->query_error,
                         "Invalid predicate in pattern at row %u: regular expression error", row);
                     goto error;


### PR DESCRIPTION
The `_PyErr_FormatFromCause` function is a private function, which was never documented. While it existed for a long time, it was removed in Python 3.13 https://github.com/python/cpython/issues/106320.

Use instead the public function `PyErr_Format`, which is also part of the stable API.