### PR TITLE
Add testing of Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
Python 3.13 was officially released yesterday (Oct 7). As a result, tree-sitter should ideally now be testing with it.