### PR TITLE
fix(query): iterate over captures for the shortest size, not longest

### DIFF
--- a/tree_sitter/binding/query_predicates.c
+++ b/tree_sitter/binding/query_predicates.c
@@ -70,7 +70,7 @@ static inline bool satisfies_eq_capture(ModuleState *state, QueryPredicateEqCapt
     PyObject *text1, *text2;
     size_t size1 = (size_t)PyList_Size(nodes1), size2 = (size_t)PyList_Size(nodes2);
     int result = 1;
-    for (size_t i = 0, l = size1 > size2 ? size1 : size2; i < l; ++i) {
+    for (size_t i = 0, l = size1 < size2 ? size1 : size2; i < l; ++i) {
         text1 = node_get_text((Node *)PyList_GetItem(nodes1, i), NULL);
         text2 = node_get_text((Node *)PyList_GetItem(nodes2, i), NULL);
         result = PREDICATE_CMP(text1, text2, predicate);


### PR DESCRIPTION
Closes #308 

### Problem

The condition for iterating in `satisfies_eq_capture` was wrong, it should not iterate for whichever amount between the length of the first node array and the length of the second node array is larger. It should take the shortest length, since both must be valid.

### Solution

In the condition, set `l` to the shortest number between `size1` and `size2`. This mimics the Rust code [here](https://github.com/tree-sitter/tree-sitter/blob/d3a127a48fe8ec2c1552f82f6b25621e69d46140/lib/binding_rust/lib.rs#L2782)