### PR TITLE
Support callables that return simple buffers as input for Parser.parse

### DIFF
--- a/tree_sitter/__init__.pyi
+++ b/tree_sitter/__init__.pyi
@@ -282,7 +282,7 @@ class Parser:
     @overload
     def parse(
         self,
-        read_callback: Callable[[int, Point], bytes | None],
+        read_callback: Callable[[int, Point], ByteString | None],
         /,
         old_tree: Tree | None = None,
         encoding: Literal["utf8", "utf16", "utf16le", "utf16be"] = "utf8",


### PR DESCRIPTION
Currently `Parser.parse` can take either a single buffer as source or a callable that returns a byte string, but not a callable that returns a `memoryview`/`bytearray`.
This extends the `Parser.parse` method to take any callable that returns a simple buffer. 