### PR TITLE
Fix missing ref counting for Language.tree

### DIFF
--- a/tree_sitter/binding/parser.c
+++ b/tree_sitter/binding/parser.c
@@ -208,6 +208,7 @@ PyObject *parser_parse(Parser *self, PyObject *args, PyObject *kwargs) {
     tree->language = self->language;
     tree->source = keep_text ? source_or_callback : Py_None;
     Py_INCREF(tree->source);
+    Py_INCREF(tree->language);
     return PyObject_Init((PyObject *)tree, state->tree_type);
 }
 

--- a/tree_sitter/binding/tree.c
+++ b/tree_sitter/binding/tree.c
@@ -4,6 +4,7 @@ PyObject *node_new_internal(ModuleState *state, TSNode node, PyObject *tree);
 
 void tree_dealloc(Tree *self) {
     ts_tree_delete(self->tree);
+    Py_XDECREF(self->language);
     Py_XDECREF(self->source);
     Py_TYPE(self)->tp_free(self);
 }


### PR DESCRIPTION
This PR adds a missing `Py_INCREF`/`Py_XDECREF` for the `Language` object stored in the `Tree` class.
The `Tree` class holds a reference to the `Language` object without incrementing/decrementing its reference count. This can result in the `Language` object being prematurely freed, resulting in a use after free when accessing `tree.language`.

Note, that while adding these, I saw that the `tree_copy` is not copying the language/source fields. I'm not sure if that is intended. If not, this would also need reference incrementing like this:
```c
Py_XINCREF(self->language);
copied->language = self->language;
Py_XINCREF(self->source);
copied->source = self->source;
```