### PR TITLE
Fix tree_copy missing language and source fields

### DIFF
--- a/tree_sitter/binding/tree.c
+++ b/tree_sitter/binding/tree.c
@@ -83,6 +83,10 @@ PyObject *tree_copy(Tree *self, PyObject *Py_UNUSED(args)) {
     }
 
     copied->tree = ts_tree_copy(self->tree);
+    copied->language = self->language;
+    Py_XINCREF(self->language);
+    copied->source = self->source;
+    Py_XINCREF(self->source);
     return PyObject_Init((PyObject *)copied, state->tree_type);
 }
 


### PR DESCRIPTION
Follow up to #381.
Adds copying of missing fields `language` and `source` in `tree_copy`.