### PR TITLE
fix(docs): QueryCursor page was missing from index

### DIFF
--- a/docs/classes/tree_sitter.QueryCursor.rst
+++ b/docs/classes/tree_sitter.QueryCursor.rst
@@ -1,4 +1,4 @@
-Query
+QueryCursor
 =====
 
 .. autoclass:: tree_sitter.QueryCursor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Classes
    tree_sitter.Parser
    tree_sitter.Point
    tree_sitter.Query
+   tree_sitter.QueryCursor
    tree_sitter.QueryError
    tree_sitter.QueryPredicate
    tree_sitter.Range


### PR DESCRIPTION
## Problem

I was reading the docs and couldn't find a way to the `QueryCursor` page. Previous ci logs actually warned about this page being isolated:

```
... docs/classes/tree_sitter.QueryCursor.rst: WARNING: document isn't included in any toctree [toc.not_included]
```

By the way, the heading of the page was `Query` instead of `QueryCursor`.

## This PR

This pull request updates the documentation to include the `QueryCursor` class and corrects a heading mismatch in its documentation file.

Documentation updates:

* [`docs/classes/tree_sitter.QueryCursor.rst`](diffhunk://#diff-bd98119c6deb15ff71a57da09ea986d4a683a08ff5a5db685b86b6567ad534abL1-R1): Corrected the heading from "Query" to "QueryCursor" to match the class name.
* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R39): Added `tree_sitter.QueryCursor` to the list of documented classes in the index.