### PR TITLE
fix: pattern_index parameter to generic predicates is incorrect

### DIFF
--- a/tree_sitter/binding/query.c
+++ b/tree_sitter/binding/query.c
@@ -437,6 +437,7 @@ PyObject *query_new(PyTypeObject *cls, PyObject *args, PyObject *Py_UNUSED(kwarg
                     PyObject_New(QueryPredicateGeneric, state->query_predicate_generic_type);
                 predicate->predicate = PyUnicode_FromStringAndSize(predicate_name, length);
                 predicate->arguments = PyList_New(predicate_len - 1);
+				predicate->pattern_index = i;
                 for (uint32_t k = 1; k < predicate_len; ++k) {
                     PyObject *item;
                     if ((predicate_step + k)->type == TSQueryPredicateStepTypeCapture) {

--- a/tree_sitter/binding/query_predicates.c
+++ b/tree_sitter/binding/query_predicates.c
@@ -161,7 +161,8 @@ bool query_satisfies_predicates(Query *query, TSQueryMatch match, Tree *tree, Py
             }
             QueryPredicateGeneric *predicate = (QueryPredicateGeneric *)item;
             PyObject *result = PyObject_CallFunction(callable, "OOIO", predicate->predicate,
-                                                     predicate->arguments, i, captures);
+                                                     predicate->arguments,
+													 predicate->pattern_index, captures);
             if (result == NULL) {
                 is_satisfied = false;
                 break;

--- a/tree_sitter/binding/types.h
+++ b/tree_sitter/binding/types.h
@@ -76,6 +76,7 @@ typedef struct {
     PyObject_HEAD
     PyObject *predicate;
     PyObject *arguments;
+	uint32_t pattern_index;
 } QueryPredicateGeneric;
 
 typedef struct {


### PR DESCRIPTION
When a generic predicate callable is used, the documented signature indicates that the third argument should be the pattern index. Unfortunately, the value that was being passed was an index into an internal array of only the patterns containing predicates, not the true index of the pattern. This made it impossible for a custom directive to store information into the relevant `pattern_settings` dict (similar to how the built-in `#set!` directive does).

This change fixes that by storing the pattern index into the `QueryPredicateGeneric` structure, and then plumbing that through to the predicate callable.