### PR TITLE
parser.parse: support encoding=None

### DIFF
--- a/tree_sitter/binding/parser.c
+++ b/tree_sitter/binding/parser.c
@@ -140,6 +140,7 @@ PyObject *parser_parse(Parser *self, PyObject *args, PyObject *kwargs) {
         if (progress_callback_obj != NULL) {
             const char *warning = "The progress_callback is ignored when parsing a bytestring";
             if (PyErr_WarnEx(PyExc_UserWarning, warning, 1) < 0) {
+                PyBuffer_Release(&source_view);
                 return NULL;
             }
         }


### PR DESCRIPTION

support parsing binary data

```py
tree = parser.parse(b"...", encoding=None)
```

fix https://github.com/tree-sitter/tree-sitter/issues/4857
