### PR TITLE
Clarify Point.column is measured in bytes

### DIFF
--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -23,7 +23,7 @@ LogType.__doc__ = "The type of a log message."
 
 Point.__doc__ = "A position in a multi-line text document, in terms of rows and columns."
 Point.row.__doc__ = "The zero-based row of the document."
-Point.column.__doc__ = "The zero-based column of the document."
+Point.column.__doc__ = "The zero-based column of the document. Measured in bytes"
 
 
 class QueryPredicate(_Protocol):


### PR DESCRIPTION
This just updates the docs on the Point object to say the column property is measured in bytes.

When I saw column it made me think of something visually aligned. And in my head characters are what's visually aligned, not bytes.

It took too long for me to realize that gut instinct was wrong. I feel like if I made that mistake, somebody else will too so it's worth a couple words of clarification. 

Here I found someone confirming it's in bytes.
https://github.com/tree-sitter/tree-sitter/issues/397#issuecomment-515115012