### PR TITLE
ci: add riscv64 wheels to PyPI release workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -55,7 +55,7 @@ jobs:
           CIBW_ARCHS: ${{matrix.cibw_arch}}
           CIBW_SKIP: "*-musllinux_aarch64 *-musllinux_riscv64 cp31?t-*"
           # FIXME: stop skipping when the tests stop crashing
-          CIBW_TEST_SKIP: "*-win_*"
+          CIBW_TEST_SKIP: "*-win_* *-linux_riscv64"
       - name: Upload wheels
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -37,8 +37,14 @@ jobs:
           - { os: ubuntu-24.04,     cibw_arch: x86_64 }
           - { os: ubuntu-24.04-arm, cibw_arch: aarch64 }
           - { os: macos-15,         cibw_arch: arm64 }
+          - { os: ubuntu-24.04,     cibw_arch: riscv64 }
           - { os: macos-15-intel,   cibw_arch: x86_64 }
     steps:
+      - name: Set up QEMU
+        if: matrix.cibw_arch == 'riscv64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/riscv64
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -47,7 +53,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.3
         env:
           CIBW_ARCHS: ${{matrix.cibw_arch}}
-          CIBW_SKIP: "*-musllinux_aarch64 cp31?t-*"
+          CIBW_SKIP: "*-musllinux_aarch64 *-musllinux_riscv64 cp31?t-*"
           # FIXME: stop skipping when the tests stop crashing
           CIBW_TEST_SKIP: "*-win_*"
       - name: Upload wheels


### PR DESCRIPTION
## Summary

Add `linux_riscv64` wheels to the PyPI release workflow.

### Changes

- Add `{ os: ubuntu-24.04, cibw_arch: riscv64 }` to the build-wheels matrix
- Add QEMU setup step (conditional on riscv64)
- Skip `musllinux_riscv64` (no image available yet)

### Evidence

A tested riscv64 wheel is available in our community index:
https://gounthar.github.io/riscv64-python-wheels/simple/tree-sitter/

Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz, 16 GB RAM).

### Context

- `manylinux_2_28_riscv64` is available in pypa/manylinux
- cibuildwheel 3.x supports riscv64 via QEMU
- Several packages already ship riscv64 wheels on PyPI (aiohttp, yarl, multidict, regex)
- RISC-V hardware is shipping (SiFive, SpacemiT K1/K3, Sophgo SG2044)

Closes #442

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).