### PR TITLE
build: include more files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,7 @@ prune tree_sitter/core
 graft tree_sitter/core/lib/src
 graft tree_sitter/core/lib/include/tree_sitter
 prune tree_sitter/core/lib/src/wasm
+
+graft docs
+graft examples
+graft tests


### PR DESCRIPTION
Add docs, examples, and tests to the source tarball, so that distributions packaging the project from PyPI sources can use them during build and/or package them.