### PR TITLE
fix(node): fix text handling for bytes-like callbacks

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -465,6 +465,24 @@ class TestNode(TestCase):
         close_delim_node = list_node.children[4]
         self.assertEqual(close_delim_node.text, b"]")
 
+    def test_text_with_callback_source(self):
+        parser = Parser(self.python)
+        source_code = b"def foo():\n    return 1\n"
+        source_lines = source_code.splitlines(keepends=True)
+
+        def callback_slice(factory, _, point):
+            row, column = point
+            if row >= len(source_lines):
+                return None
+            if column >= len(source_lines[row]):
+                return None
+            return factory(source_lines[row][column:])
+
+        for factory in (bytes, bytearray, memoryview):
+            with self.subTest(type=factory.__name__):
+                tree = parser.parse(lambda *args, factory=factory: callback_slice(factory, *args))
+                self.assertEqual(tree.root_node.text, source_code)
+
     def test_hash(self):
         parser = Parser(self.python)
         source_code = b"def foo():\n  bar()\n  bar()"

--- a/tree_sitter/binding/node.c
+++ b/tree_sitter/binding/node.c
@@ -625,6 +625,15 @@ PyObject *node_get_text(Node *self, void *Py_UNUSED(payload)) {
                 return NULL;
             }
 
+            Py_ssize_t bytes_read = PyByteArray_Size(rv_bytearray);
+            char *rv_str = PyByteArray_AsString(rv_bytearray);
+            if (bytes_read < 0 || rv_str == NULL) {
+                Py_DECREF(rv_bytearray);
+                Py_DECREF(collected_bytes);
+                Py_XDECREF(rv);
+                return NULL;
+            }
+
             PyObject *new_collected_bytes = PyByteArray_Concat(collected_bytes, rv_bytearray);
             Py_DECREF(rv_bytearray);
             Py_DECREF(collected_bytes);
@@ -634,10 +643,8 @@ PyObject *node_get_text(Node *self, void *Py_UNUSED(payload)) {
             }
             collected_bytes = new_collected_bytes;
 
-            size_t bytes_read = (size_t)PyBytes_Size(rv);
-            const char *rv_str = PyBytes_AsString(rv);
             Py_XDECREF(rv);
-            for (size_t i = 0; i < bytes_read; ++i) {
+            for (Py_ssize_t i = 0; i < bytes_read; ++i) {
                 if (rv_str[i] == '\n') {
                     ++current_point.row;
                     current_point.column = 0;
@@ -645,7 +652,7 @@ PyObject *node_get_text(Node *self, void *Py_UNUSED(payload)) {
                     ++current_point.column;
                 }
             }
-            current_offset += bytes_read;
+            current_offset += (size_t)bytes_read;
         }
 
         PyObject *start_byte = PyLong_FromSize_t(0);


### PR DESCRIPTION
## Summary

Fix a segfault in `Node.text` when the parse source comes from a callback returning a bytes-like object.

Related to #435.

## What changed

- Updated the callable-source branch in `node_get_text` to use the normalized `bytearray` buffer when computing length and reading bytes.
- Added regression coverage for callback sources returning:
  - `bytes`
  - `bytearray`
  - `memoryview`

## Why

The previous implementation accepted bytes-like callback results, but later treated the original callback return value as if it were always a `bytes` object. That could segfault when `Node.text` was accessed.

This change addresses a `node_get_text` crash in the same area discussed in #435.

## Testing

- `python -m unittest discover -s tests -v`