### PR TITLE
fix(language): use PyLong_AsSize_t for pointer-sized language IDs

### DIFF
--- a/tree_sitter/binding/language.c
+++ b/tree_sitter/binding/language.c
@@ -9,7 +9,7 @@ int language_init(Language *self, PyObject *args, PyObject *Py_UNUSED(kwargs)) {
     if (PyCapsule_CheckExact(language)) {
         self->language = PyCapsule_GetPointer(language, "tree_sitter.Language");
     } else {
-        Py_uintptr_t language_id = PyLong_AsUnsignedLong(language);
+        Py_uintptr_t language_id = PyLong_AsSize_t(language);
         if (language_id == 0 || (language_id % sizeof(TSLanguage *)) != 0) {
             if (!PyErr_Occurred()) {
                 PyErr_SetString(PyExc_ValueError, "invalid language ID");


### PR DESCRIPTION
Fixes #469.
PyLong_AsUnsignedLong was introduced in 14e7893 for a value that's actually a pointer (Py_uintptr_t). On 64-bit Windows (LLP64), unsigned long is 32-bit while pointers are 64-bit, so this overflows for any real pointer value passed to the deprecated int-based Language() constructor — exactly the OverflowError reported in the issue.
Reverted that one call to PyLong_AsSize_t, which is pointer-width on all platforms (including Win64), matching the pre-refactor behavior. This doesn't affect the other unsigned long conversions from that commit, since those hold 32-bit byte offsets/counts, not pointers.