### PR TITLE
fix(query): fix reference leak in captures_for_match

### DIFF
--- a/tree_sitter/binding/query_predicates.c
+++ b/tree_sitter/binding/query_predicates.c
@@ -35,13 +35,23 @@ static inline PyObject *captures_for_match(ModuleState *state, TSQuery *query, T
         const char *capture_name = ts_query_capture_name_for_id(query, capture.index, &name_length);
         PyObject *capture_name_obj = PyUnicode_FromStringAndSize(capture_name, name_length);
         if (capture_name_obj == NULL) {
+            Py_DECREF(captures);
             return NULL;
         }
         PyObject *nodes = nodes_for_capture_index(state, capture.index, match, tree);
+        if (nodes == NULL) {
+            Py_DECREF(captures);
+            Py_DECREF(capture_name_obj);
+            return NULL;
+        }
         if (PyDict_SetItem(captures, capture_name_obj, nodes) == -1) {
+            Py_DECREF(captures);
+            Py_DECREF(capture_name_obj);
+            Py_DECREF(nodes);
             return NULL;
         }
         Py_DECREF(capture_name_obj);
+        Py_DECREF(nodes);
     }
     return captures;
 }


### PR DESCRIPTION
Fixes #467.

`nodes_for_capture_index()` returns a new reference, and `PyDict_SetItem()` doesn't steal it — it takes its own independent reference to the same object. The local `nodes` variable (and `captures` on the error paths) was never released, so every capture evaluated through a custom query predicate leaked one node-list object permanently.

Verified the leak and the fix by comparing `sys.getrefcount()` on the captured list inside a custom predicate callback: 4 references before the fix, 3 after — matching the expected single-owner (the dict) refcount.