### PR TITLE
test(point): regression test for Point row/column reference counting (#466)

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,3 +1,4 @@
+import sys
 from typing import cast
 from unittest import TestCase
 
@@ -115,6 +116,42 @@ class TestNode(TestCase):
         self.assertEqual(child.byte_range, (11, 14))
         self.assertEqual(child.start_point, (2, 7))
         self.assertEqual(child.end_point, (2, 10))
+
+    def test_point_getters_return_new_references(self):
+        # Regression test for the reference-counting bug fixed in #466: the
+        # `Point.row` / `Point.column` getters must return a *new* reference per
+        # the C-API contract, not a borrowed one. Returning a borrowed reference
+        # leaves the underlying row/column int one refcount too low, which frees
+        # it prematurely and corrupts the allocator free list — surfacing much
+        # later as a hard SIGSEGV while indexing real files. It only bites for
+        # non-immortal ints, i.e. row/column values past the small-int cache, so
+        # this uses a node whose start point is well beyond it.
+        if not hasattr(sys, "getrefcount"):
+            self.skipTest("reference-count semantics are CPython-specific")
+
+        parser = Parser(self.python)
+        tree = parser.parse(b"\n" * 500 + b" " * 500 + b"name123\n")
+        node = cast(Node, tree.root_node.descendant_for_byte_range(1000, 1006))
+        point = node.start_point
+        # Tuple subscripting (point[i]) returns a correctly-owned reference, so
+        # it is safe to use for measuring the row/column ints' refcounts. Both
+        # values are 500 — comfortably past the small-int / immortal cache, so a
+        # missing incref is observable rather than masked.
+        self.assertLess(sys.getrefcount(point[0]), 2**30, "row must be a non-immortal int")
+        self.assertLess(sys.getrefcount(point[1]), 2**30, "column must be a non-immortal int")
+
+        for index, name in ((0, "row"), (1, "column")):
+            before = sys.getrefcount(point[index])
+            held = getattr(point, name)
+            after = sys.getrefcount(point[index])
+            # Assert the getter took its own reference *before* ``held`` is
+            # dropped: with the borrowed-reference bug this fails here, avoiding
+            # the eventual over-decref (which would otherwise free the int early
+            # and corrupt the allocator).
+            self.assertEqual(
+                after, before + 1, f"Point.{name} must return a new reference, not a borrowed one"
+            )
+            self.assertEqual(held, 500)
 
     def test_descendant_count(self):
         parser = Parser(self.json)


### PR DESCRIPTION
## Summary

Adds a regression test for the `Point.row` / `Point.column` reference-counting bug fixed in #466. That PR corrected the getters but did not add a test, and the existing suite can't catch this class of bug (its `start_point` assertions all use small, immortal-int values).

## Background

Before #466, `point_get_row` / `point_get_column` returned `PyTuple_GetItem(self, i)` — a **borrowed** reference — where a get/set getter must return a **new** reference. The row/column `int` was left one refcount too low, so it was freed prematurely and corrupted the pymalloc free list, eventually causing a hard **SIGSEGV**.

It only reproduces for **non-immortal ints** — i.e. line/column numbers past CPython's small-int cache (>256) — which is why it surfaced when indexing real, large source files but never with small test fixtures. I ran into it downstream and tracked it to this getter (independently confirmed with AddressSanitizer: a wild `TSNode` pointer in `ts_node_end_byte`, one over-decref removed and the crash disappears). See tree-sitter/py-tree-sitter#472 for the original report.

## The test

`test_point_getters_return_new_references` builds a node whose start point is `(500, 500)` (both values outside the immortal range) and asserts each getter increments the referent's refcount by exactly one. It measures refcounts via tuple subscripting (`point[i]`, which is correctly owned) and asserts before the borrowed reference can do harm, so it **fails cleanly** on the pre-#466 binding rather than crashing.

Verified:
- **Passes** on current `master` (post-#466).
- **Fails** (`AssertionError: 2 != 3 : Point.row must return a new reference…`) when #466's `point.c` change is reverted — no segfault.
- Full suite: `61 passed, 20 subtests passed`.

The test is skipped on non-CPython implementations (no `sys.getrefcount`).
